### PR TITLE
A testing library is probably not an install dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ from distutils import sysconfig
 
 
 print("packages:", find_packages())
- 
+
 setup_requires = [
         'numpy',
         ]
@@ -23,7 +23,6 @@ install_requires = [
         'pandas',
         'slugid',
         'sortedcontainers',
-        'nose',
         'cooler>=0.8.0',
         'pybbi==0.2.0',
         'Click']


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Remove `nose` from `install_requires`

Why is it necessary?
- Testing library is not necessary when the library is installed.

## Checklist

- [ ] Unit tests added or updated
- [ ] Updated CHANGELOG.md
