### PR TITLE
Mccalluc/autopep8 little steps

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -40,26 +40,10 @@ exclude =
   notebooks/ENSEMBL annotations and RNAseq.ipynb
   notebooks/h37rv gene annotations.ipynb
   pyprof.sh
-  scripts/big_spark.py
-  scripts/check_sorted.py
-  scripts/conversion_wrapper.py
-  scripts/cooler_to_tiles.py
-  scripts/create_chrominfo.py
   scripts/exonU.py
-  scripts/get_hitile.py
   scripts/gff_to_chromsizes.py
   scripts/gff_to_genepred.py
-  scripts/make_autocomplete_list.py
-  scripts/make_big_file.py
-  scripts/make_single_threaded_tiles.py
-  scripts/make_streaming_tiles.py
-  scripts/make_tiles.py
-  scripts/process_file.py
-  scripts/pyprof.sh
   scripts/replace_importances.py
-  scripts/temp.py
-  scripts/test_1d.py
-  scripts/tile_1d.py
   scripts/tsv_to_mrmatrix.py
   setup.py
   test/bedfile_test.py

--- a/.flake8
+++ b/.flake8
@@ -1,42 +1,94 @@
 [flake8]
-exclude = .eggs, src/multiprocess
-  # src/multiprocess is on Travis, but not in my local checkout.
+exclude =
+  .eggs
+  src/multiprocess # on Travis, but not in my local checkout.
+  clodius/array.py
+  clodius/chromosomes.py
+  clodius/cli/__init__.py
+  clodius/cli/aggregate.py
+  clodius/cli/convert.py
+  clodius/cli/utils.py
+  clodius/db_tiles.py
+  clodius/describe_dataset.py
+  clodius/fpark.py
+  clodius/hdf_tiles.py
+  clodius/higlass_getter.py
+  clodius/multivec.py
+  clodius/save_tiles.py
+  clodius/tiles/bed2ddb.py
+  clodius/tiles/bedarcsdb.py
+  clodius/tiles/beddb.py
+  clodius/tiles/bedfile.py
+  clodius/tiles/bigwig.py
+  clodius/tiles/chromsizes.py
+  clodius/tiles/cooler.py
+  clodius/tiles/density.py
+  clodius/tiles/files.py
+  clodius/tiles/format.py
+  clodius/tiles/geo.py
+  clodius/tiles/hitile.py
+  clodius/tiles/imtiles.py
+  clodius/tiles/mrmatrix.py
+  clodius/tiles/multivec.py
+  clodius/tiles/nplabels.py
+  clodius/tiles/npmatrix.py
+  clodius/tiles/npvector.py
+  clodius/tiles/points.py
+  clodius/tiles/time_interval.py
+  clodius/tiles/utils.py
+  notebooks/Aggregating an array.ipynb
+  notebooks/ENSEMBL annotations and RNAseq.ipynb
+  notebooks/h37rv gene annotations.ipynb
+  pyprof.sh
+  scripts/big_spark.py
+  scripts/check_sorted.py
+  scripts/conversion_wrapper.py
+  scripts/cooler_to_tiles.py
+  scripts/create_chrominfo.py
+  scripts/exonU.py
+  scripts/get_hitile.py
+  scripts/gff_to_chromsizes.py
+  scripts/gff_to_genepred.py
+  scripts/make_autocomplete_list.py
+  scripts/make_big_file.py
+  scripts/make_single_threaded_tiles.py
+  scripts/make_streaming_tiles.py
+  scripts/make_tiles.py
+  scripts/process_file.py
+  scripts/pyprof.sh
+  scripts/replace_importances.py
+  scripts/temp.py
+  scripts/test_1d.py
+  scripts/tile_1d.py
+  scripts/tsv_to_mrmatrix.py
+  setup.py
+  test/bedfile_test.py
+  test/bedpe_test.py
+  test/cli_test.py
+  test/fpark_test.py
+  test/mrmatrix_test.py
+  test/multivec_test.py
+  test/tile_2d_bedfile_test.py
+  test/tiles/bed2ddb_test.py
+  test/tiles/bedarcsdb.py
+  test/tiles/beddb_test.py
+  test/tiles/bigwig_test.py
+  test/tiles/cooler_test.py
+  test/tiles/density_test.py
+  test/tiles/files_test.py
+  test/tiles/hitile_test.py
+  test/tiles/multivec_test.py
+  test/tiles/npmatrix_test.py
+  test/tiles/npvector_test.py
+  test/tiles/time_interval_test.py
+  test/tsv_to_mrmatrix_test.py
+  test/utils.py
+  test.py
 
 ignore =
-  E111 # indentation is not a multiple of four
-  E116 # unexpected indentation (comment)
-  E117 # over-indented
-  E121 # continuation line under-indented for hanging indent
-  E123 # closing bracket does not match indentation of opening bracket's line
-  E124 # closing bracket does not match visual indentation
-  E125 # continuation line with same indent as next logical line
-  E126 # continuation line over-indented for hanging indent
-  E127 # continuation line over-indented for visual indent
-  E128 # continuation line under-indented for visual indent
-  E131 # continuation line unaligned for hanging indent
-  E201 # whitespace after
-  E202 # whitespace before
   E203 # whitespace before
-  E221 # multiple spaces before operator
-  E222 # multiple spaces after operator
-  E225 # missing whitespace around operator
-  E226 # missing whitespace around arithmetic operator
-  E231 # missing whitespace after
-  E241 # multiple spaces after
-  E251 # unexpected spaces around keyword / parameter equals
-  E261 # at least two spaces before inline comment
-  E262 # inline comment should start with '# '
   E265 # block comment should start with '# '
-  E271 # multiple spaces after keyword
-  E302 # expected 2 blank lines
-  E303 # too many blank lines
-  E305 # expected 2 blank lines after class or function definition
-  E306 # expected 1 blank line before a nested definition
-  E401 # multiple imports on one line
-  E402 # module level import not at top of
   E501 # line too long
-  E701 # multiple statements on one line (colon)
-  E703 # statement ends with a semicolon
   E711 # comparison to None should be 'if cond is not None:'
   E712 # comparison to True should be 'if cond is True:' or 'if cond:'
   E713 # test for membership should be 'not in'

--- a/.flake8
+++ b/.flake8
@@ -63,12 +63,9 @@ exclude =
   scripts/tsv_to_mrmatrix.py
   setup.py
   test/bedfile_test.py
-  test/bedpe_test.py
   test/cli_test.py
-  test/fpark_test.py
   test/mrmatrix_test.py
   test/multivec_test.py
-  test/tile_2d_bedfile_test.py
   test/tiles/bed2ddb_test.py
   test/tiles/bedarcsdb.py
   test/tiles/beddb_test.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 flake8==3.7.7
 nose==1.3.7
+autopep8==1.4.4

--- a/scripts/big_spark.py
+++ b/scripts/big_spark.py
@@ -3,13 +3,14 @@
 import argparse
 from pyspark import SparkContext
 
+
 def main():
     usage = """
     python big_spark.py
 
     Parse a large input file, group its input by key and output it somewhere.
     """
-    num_args= 1
+    num_args = 1
     parser = argparse.ArgumentParser()
 
     parser.add_argument("input_file")
@@ -21,7 +22,8 @@ def main():
 
     print "entries.take(1):", entries.take(1)
 
-    #entries.reduceByKey(reduceByKeyFunc
+    # entries.reduceByKey(reduceByKeyFunc
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/check_sorted.py
+++ b/scripts/check_sorted.py
@@ -23,7 +23,7 @@ for line in sys.stdin:
         if (curr_val2 < prev_val2):
             print >>sys.stderr, "Not sorted, line:", counter
             sys.exit(1)
-    
+
     prev_val = curr_val
     prev_val2 = curr_val2
     counter += 1

--- a/scripts/conversion_wrapper.py
+++ b/scripts/conversion_wrapper.py
@@ -6,13 +6,18 @@ import os
 import os.path as op
 import sys
 
+
 def set_postmortem_hook():
-    import sys, traceback, ipdb
+    import sys
+    import traceback
+    import ipdb
+
     def _excepthook(exc_type, value, tb):
         traceback.print_exception(exc_type, value, tb)
         print()
         ipdb.pm()
     sys.excepthook = _excepthook
+
 
 set_postmortem_hook()
 
@@ -53,7 +58,6 @@ def main():
     n_cpus = args["n_cpus"]
     chunk_size = args["chunk_size"]
 
-
     if output_file is None:
         output_file = format_output_filename(input_file, filetype)
 
@@ -62,7 +66,8 @@ def main():
         sys.stdout.write("Output to stdout")
 
     if filetype in ["bigwig", "hitile"]:
-        cca._bigwig(filepath=input_file, output_file=output_file, assembly=assembly)
+        cca._bigwig(filepath=input_file,
+                    output_file=output_file, assembly=assembly)
 
     if filetype == "cooler":
         from cooler.contrib import recursive_agg_onefile
@@ -87,9 +92,9 @@ def format_output_filename(input_file, filetype):
     input_file_basename = os.path.basename(input_file)
 
     file_extentions = {
-        "gene_annotation" : "bed",
-        "hitile" : "hitile",
-        "cooler" : "cool",
+        "gene_annotation": "bed",
+        "hitile": "hitile",
+        "cooler": "cool",
         "bigwig": "bw"
     }
 

--- a/scripts/cooler_to_tiles.py
+++ b/scripts/cooler_to_tiles.py
@@ -13,7 +13,8 @@ import time
 
 import multiprocessing as mpr
 
-def recursive_generate_tiles(tile_positions, coolers_matrix, info, resolution, max_zoom_to_generate, queue = None, max_queue_size=10000):
+
+def recursive_generate_tiles(tile_positions, coolers_matrix, info, resolution, max_zoom_to_generate, queue=None, max_queue_size=10000):
     '''
     Recursively generate tiles from a cooler file.
 
@@ -43,9 +44,10 @@ def recursive_generate_tiles(tile_positions, coolers_matrix, info, resolution, m
         end2 = (y_pos + 1) * info['max_width'] / divisor
 
         t1 = time.time()
-        print("st:", start1, end1-1, start2, end2-1)
+        print("st:", start1, end1 - 1, start2, end2 - 1)
         try:
-            data = chg.getData3(coolers_matrix[zoom_level], zoom_level, start1, end1-1, start2, end2-1)
+            data = chg.getData3(
+                coolers_matrix[zoom_level], zoom_level, start1, end1 - 1, start2, end2 - 1)
         except ValueError as ve:
             print("ERROR ve:", ve, file=sys.stderr)
 
@@ -61,22 +63,24 @@ def recursive_generate_tiles(tile_positions, coolers_matrix, info, resolution, m
         j = (df['genome_end'].values - start2) // binsize
         v = np.nan_to_num(df['balanced'].values)
         m = (end1 - start1) // binsize
-        n =  (end2 - start2) // binsize
+        n = (end2 - start2) // binsize
 
-        zi = zip(zip(i,j),v)
+        zi = zip(zip(i, j), v)
         tile_bins = dict(zi)
 
         data_length = len(data)
 
         if queue is not None:
             total_put += 1
-            print("putting:", (tile_position[0], tile_position[1:]), 
-                  "total_put:", total_put, 
+            print("putting:", (tile_position[0], tile_position[1:]),
+                  "total_put:", total_put,
                   "total_time: {:d}".format(int(time.time() - start_time)),
-                  "time_per_put: {:.2f}".format((time.time() -  start_time) / total_put),
+                  "time_per_put: {:.2f}".format(
+                      (time.time() - start_time) / total_put),
                   "data_time: {:.2f}".format(data_time),
                   "tile_size:", data_length,
-                  "call: ({}, {}, {}, {}, {})".format(zoom_level, start1, end1-1, start2, end2-1),
+                  "call: ({}, {}, {}, {}, {})".format(
+                      zoom_level, start1, end1 - 1, start2, end2 - 1),
                   'qsize:', queue.qsize())
             queue.put((tile_position[0], tile_position[1:], tile_bins))
             while queue.qsize() > max_queue_size:
@@ -85,10 +89,11 @@ def recursive_generate_tiles(tile_positions, coolers_matrix, info, resolution, m
         # Upload the tile to the server here
         ###
         if zoom_level < max_zoom_to_generate and data_length > 0:
-            tile_positions.append((zoom_level+1, 2 * x_pos, 2 * y_pos))
-            tile_positions.append((zoom_level+1, 2 * x_pos, 2 * y_pos + 1))
-            tile_positions.append((zoom_level+1, 2 * x_pos+1, 2 * y_pos + 1))
-            tile_positions.append((zoom_level+1, 2 * x_pos+1, 2 * y_pos))
+            tile_positions.append((zoom_level + 1, 2 * x_pos, 2 * y_pos))
+            tile_positions.append((zoom_level + 1, 2 * x_pos, 2 * y_pos + 1))
+            tile_positions.append(
+                (zoom_level + 1, 2 * x_pos + 1, 2 * y_pos + 1))
+            tile_positions.append((zoom_level + 1, 2 * x_pos + 1, 2 * y_pos))
 
         # need to recurse into higher zoom levels
         '''
@@ -102,6 +107,7 @@ def recursive_generate_tiles(tile_positions, coolers_matrix, info, resolution, m
                 resolution, max_zoom_to_generate, queue = queue)
         '''
 
+
 def main():
     parser = argparse.ArgumentParser(description="""
     python cooler_to_tiles.py cooler_file 
@@ -110,9 +116,9 @@ def main():
 """)
 
     #parser.add_argument('argument', nargs=1)
-    #parser.add_argument('-o', '--options', default='yo',
+    # parser.add_argument('-o', '--options', default='yo',
     #					 help="Some option", type='str')
-    #parser.add_argument('-u', '--useless', action='store_true', 
+    # parser.add_argument('-u', '--useless', action='store_true',
     #					 help='Another useless option')
     parser.add_argument('filepath')
     parser.add_argument('-e', '--elasticsearch-url', default=None,
@@ -135,18 +141,18 @@ def main():
     bins_per_dimension = tileset_info['bins_per_dimension']
     max_data_in_sparse = bins_per_dimension ** num_dimensions / 10
 
-    if args.elasticsearch_url is not None:    
+    if args.elasticsearch_url is not None:
         tile_saver = cst.ElasticSearchTileSaver(max_data_in_sparse,
                                                 bins_per_dimension,
-                                                es_path = args.elasticsearch_url,
-                                                log_file = args.log_file,
+                                                es_path=args.elasticsearch_url,
+                                                log_file=args.log_file,
                                                 num_dimensions=num_dimensions)
     else:
         tile_saver = cst.ColumnFileTileSaver(max_data_in_sparse,
-                                                bins_per_dimension,
-                                                file_path = args.columnfile_path,
-                                                log_file = args.log_file,
-                                                num_dimensions=num_dimensions)
+                                             bins_per_dimension,
+                                             file_path=args.columnfile_path,
+                                             log_file=args.log_file,
+                                             num_dimensions=num_dimensions)
 
     ############################################################################
 
@@ -163,7 +169,8 @@ def main():
 
     print("num_threads:", args.num_threads)
     for i in range(args.num_threads):
-        p = mpr.Process(target=cst.tile_saver_worker, args=(queue, tile_saver, finished))
+        p = mpr.Process(target=cst.tile_saver_worker,
+                        args=(queue, tile_saver, finished))
 
         p.daemon = True
         p.start()
@@ -172,13 +179,13 @@ def main():
     tileset_info['max_value'] = 0
     tileset_info['min_value'] = 0
 
-    tile_saver.save_tile({'tile_id': 'tileset_info', 
+    tile_saver.save_tile({'tile_id': 'tileset_info',
                           'tile_value': tileset_info})
     tile_saver.flush()
 
     try:
         with h5py.File(args.filepath) as f:
-            for i in range(max_zoom_to_generate+1):
+            for i in range(max_zoom_to_generate + 1):
                 f = h5py.File(args.filepath, 'r')
 
                 c = cooler.Cooler(f[str(i)])
@@ -186,8 +193,8 @@ def main():
 
                 coolers_matrix[i] = {'cooler': c, 'matrix': matrix}
 
-            recursive_generate_tiles(col.deque([(0,0,0)]), coolers_matrix, tileset_info, 
-                    args.resolution, max_zoom_to_generate, queue)
+            recursive_generate_tiles(col.deque([(0, 0, 0)]), coolers_matrix, tileset_info,
+                                     args.resolution, max_zoom_to_generate, queue)
     except KeyboardInterrupt:
         print("kb interrupt:")
         for (ts, p) in tilesaver_processes:
@@ -202,12 +209,10 @@ def main():
         p.join()
 
     print("tileset_info:", tileset_info)
-    tile_saver.save_tile({'tile_id': 'tileset_info', 
+    tile_saver.save_tile({'tile_id': 'tileset_info',
                           'tile_value': tileset_info})
     tile_saver.flush()
 
 
 if __name__ == '__main__':
     main()
-
-

--- a/scripts/create_chrominfo.py
+++ b/scripts/create_chrominfo.py
@@ -5,6 +5,7 @@ import argparse
 import gzip
 import sys
 
+
 def main():
     parser = argparse.ArgumentParser(description="""
     
@@ -43,9 +44,9 @@ def main():
     print("{}\t{}".format(curr_name, curr_size))
 
     #parser.add_argument('argument', nargs=1)
-    #parser.add_argument('-o', '--options', default='yo',
+    # parser.add_argument('-o', '--options', default='yo',
     #					 help="Some option", type='str')
-    #parser.add_argument('-u', '--useless', action='store_true', 
+    # parser.add_argument('-u', '--useless', action='store_true',
     #					 help='Another useless option')
     '''
     for record in fseq:
@@ -55,9 +56,6 @@ def main():
     args = parser.parse_args()
     '''
 
-    
 
 if __name__ == '__main__':
     main()
-
-

--- a/scripts/get_hitile.py
+++ b/scripts/get_hitile.py
@@ -7,6 +7,7 @@ import h5py
 import sys
 import argparse
 
+
 def main():
     parser = argparse.ArgumentParser(description="""
 
@@ -17,9 +18,9 @@ def main():
     parser.add_argument('z', type=int)
     parser.add_argument('x', type=int)
     #parser.add_argument('argument', nargs=1)
-    #parser.add_argument('-o', '--options', default='yo',
+    # parser.add_argument('-o', '--options', default='yo',
     #					 help="Some option", type='str')
-    #parser.add_argument('-u', '--useless', action='store_true', 
+    # parser.add_argument('-u', '--useless', action='store_true',
     #					 help='Another useless option')
 
     args = parser.parse_args()
@@ -39,7 +40,6 @@ def main():
 
         #print("tile:", hdft.get_data(f, args.z, args.x))
 
-     
+
 if __name__ == '__main__':
     main()
-

--- a/scripts/make_autocomplete_list.py
+++ b/scripts/make_autocomplete_list.py
@@ -9,6 +9,7 @@ import os.path as op
 import sys
 import argparse
 
+
 def make_autocomplete_list(entries, options, tile_saver):
     '''
     Make a list of autocomplete suggestions for a list of json objects
@@ -32,9 +33,9 @@ def make_autocomplete_list(entries, options, tile_saver):
         # for each entry get each substring and add the entry to the list
         # of entries containing that substring
         # these lists will then be pruned down to create autocomplete suggestions
-        for size in range(0,len(entry[options.name])+1):
-            for i in range(len(entry[options.name])-size+1):
-                substr = entry[options.name][i:i+size]
+        for size in range(0, len(entry[options.name]) + 1):
+            for i in range(len(entry[options.name]) - size + 1):
+                substr = entry[options.name][i:i + size]
 
                 # make the substrings file and token friendly
                 substr = substr.replace('/', ' ').lower()
@@ -58,7 +59,8 @@ def make_autocomplete_list(entries, options, tile_saver):
 
     def save_substr_entry(entry):
         (substr_key, substr_value) = entry
-        tile_saver.save_value("ac_" + substr_key, {"suggestions": substr_value})
+        tile_saver.save_value("ac_" + substr_key,
+                              {"suggestions": substr_value})
         '''
         ess.index(es_index,
                   es_doctype,
@@ -68,6 +70,7 @@ def make_autocomplete_list(entries, options, tile_saver):
 
     reduced_substr_entries.foreach(save_substr_entry)
     tile_saver.flush()
+
 
 def main():
     parser = argparse.ArgumentParser(description="""
@@ -80,33 +83,33 @@ def main():
 
     parser.add_argument('input_file', nargs=1)
     parser.add_argument('-n', '--name', default='name',
-            help='The field in the json entry which specifies its name')
+                        help='The field in the json entry which specifies its name')
     parser.add_argument('-i', '--importance', default='importance',
-            help='The field in the json entry which specifies how important \
+                        help='The field in the json entry which specifies how important \
                   it is (more important entries are displayed higher up in \
                   the autocomplete suggestions')
     parser.add_argument('-m', '--max-entries-per-autocomplete', default=10,
-            help='The maximum number of entries to be displayed in the \
+                        help='The maximum number of entries to be displayed in the \
                   autocomplete suggestions')
     parser.add_argument('-r', '--reverse-importance', default=False,
-            action='store_true',
-            help='Use the reverse sorting of the importance value to gauge \
+                        action='store_true',
+                        help='Use the reverse sorting of the importance value to gauge \
                   the worth of individual entries')
-    parser.add_argument('-c', '--column-names', 
-            help="The column names for the input tsv file",
-            default=None)
-    parser.add_argument('-d', '--delimiter', default=None, 
-            help='The delimiter separating columns in the gene_count file')
+    parser.add_argument('-c', '--column-names',
+                        help="The column names for the input tsv file",
+                        default=None)
+    parser.add_argument('-d', '--delimiter', default=None,
+                        help='The delimiter separating columns in the gene_count file')
 
-    parser.add_argument('--elasticsearch-url', 
-            help='Specify elasticsearch nodes to push the completions to',
-            default=None)
+    parser.add_argument('--elasticsearch-url',
+                        help='Specify elasticsearch nodes to push the completions to',
+                        default=None)
     parser.add_argument('--print-status', action="store_true")
 
     args = parser.parse_args()
 
     tile_saver = cst.ElasticSearchTileSaver(es_path=args.elasticsearch_url,
-            print_status = args.print_status)
+                                            print_status=args.print_status)
 
     dataFile = cfp.FakeSparkContext.textFile(args.input_file[0])
 
@@ -115,17 +118,16 @@ def main():
 
     if args.delimiter is None:
         dataFile = (dataFile.map(lambda x: x.split())
-                            .map(lambda x: dict(zip(args.column_names,x))))
+                            .map(lambda x: dict(zip(args.column_names, x))))
     else:
         print("delimiter:", args.delimiter)
         dataFile = (dataFile.map(lambda x: x.split(args.delimiter))
-                            .map(lambda x: dict(zip(args.column_names,x))))
+                            .map(lambda x: dict(zip(args.column_names, x))))
 
     print("one:", dataFile.take(1))
 
     tiles = make_autocomplete_list(dataFile, args, tile_saver)
 
+
 if __name__ == '__main__':
     main()
-
-

--- a/scripts/make_big_file.py
+++ b/scripts/make_big_file.py
@@ -3,13 +3,14 @@
 import argparse
 import random
 
+
 def main():
     usage = """
     python make_big_file.py length
 
     Create a big file with one column and 'length' rows.
     """
-    num_args= 1
+    num_args = 1
     parser = argparse.ArgumentParser()
 
     parser.add_argument("length", type=int)
@@ -18,9 +19,10 @@ def main():
     args = parser.parse_args()
 
     for i in range(args.length):
-        print random.randint(0,args.limit)
+        print random.randint(0, args.limit)
 
-    #entries.reduceByKey(reduceByKeyFunc
+    # entries.reduceByKey(reduceByKeyFunc
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/make_single_threaded_tiles.py
+++ b/scripts/make_single_threaded_tiles.py
@@ -19,15 +19,18 @@ import traceback
 
 sys.excepthook = cst.handle_exception
 
+
 def default_tile(length):
     return np.zeros(length)
 
-def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoom, 
-        bins_per_dimension, tile_saver, expand_range, ignore_0, tileset_info, max_width,
-        triangular=False, max_queue_size = 40000, print_status=False):
+
+def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoom,
+                 bins_per_dimension, tile_saver, expand_range, ignore_0, tileset_info, max_width,
+                 triangular=False, max_queue_size=40000, print_status=False):
     active_tiles = col.defaultdict(sco.SortedList)
     max_data_in_sparse = bins_per_dimension ** len(position_cols) // 5.
-    tile_contents = col.defaultdict(lambda: col.defaultdict(lambda: col.defaultdict(ft.partial(default_tile, length=len(value_pos)))))
+    tile_contents = col.defaultdict(lambda: col.defaultdict(
+        lambda: col.defaultdict(ft.partial(default_tile, length=len(value_pos)))))
     smallest_width = max_width // (2 ** max_zoom)
 
     prev_line_num = None
@@ -36,12 +39,13 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
 
     calculated_tile_bin_positions = col.defaultdict(dict)
     for x in it.product(range(2), repeat=len(position_cols)):
-        for y in it.product(range(bins_per_dimension), repeat = len(position_cols)):
-            calculated_tile_bin_positions[x][y] = tuple([ int((bins_per_dimension * tp + bp) // 2) % bins_per_dimension for  (tp, bp) in zip(x, y)])
+        for y in it.product(range(bins_per_dimension), repeat=len(position_cols)):
+            calculated_tile_bin_positions[x][y] = tuple(
+                [int((bins_per_dimension * tp + bp) // 2) % bins_per_dimension for (tp, bp) in zip(x, y)])
 
     def add_to_next_tile(zoom_level, tile_position, tile_bins):
         next_tile_position = tuple([tp // 2 for tp in tile_position])
-        new_tile_contents = tile_contents[zoom_level-1][next_tile_position]
+        new_tile_contents = tile_contents[zoom_level - 1][next_tile_position]
 
         if next_tile_position not in active_tiles[zoom_level - 1]:
             active_tiles[zoom_level - 1].add(next_tile_position)
@@ -49,10 +53,10 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
         tile_mod_pos = tuple([tp % 2 for tp in tile_position])
         calc_bin_poss = calculated_tile_bin_positions[tile_mod_pos]
 
-        for bin_position,bin_value in tile_bins.items():
+        for bin_position, bin_value in tile_bins.items():
             #old_abs_pos = [tp * bins_per_dimension + bp for (tp, bp) in zip(tile_position, bin_position)]
             #new_bin_pos = tuple([int(op / 2) % bins_per_dimension for op in old_abs_pos])
-            #print "tile_position:", tile_position, bin_position
+            # print "tile_position:", tile_position, bin_position
             '''
             for i in range(len(tile_position)):
                 tp = tile_position[i]
@@ -77,7 +81,7 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
                 print("tile_mod_pos:", tile_mod_pos, tile_position)
                 raise
 
-    for line_num,line in enumerate(it.chain(first_lines, input_source)):
+    for line_num, line in enumerate(it.chain(first_lines, input_source)):
         # see if we have to expand any coordinate ranges
         # bedFiles are examples
         # chr1 100 102 0.5
@@ -93,27 +97,31 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
                 if line_parts[value_pos][0] == "0":
                     continue
             value = [float(line_parts[vp]) for vp in value_pos]
-            #print "entry_pos:", entry_pos, value
+            # print "entry_pos:", entry_pos, value
 
             if print_status is not None:
                 if line_num != prev_line_num and line_num % print_status == 0:
                     time_str = time.strftime("%Y-%m-%d %H:%M:%S")
-                    print( "current_time:", time_str, "line_num:", line_num, "time:", int(1000 * (time.time() - prev_time)), "total_time", int(time.time() - start_time))
+                    print("current_time:", time_str, "line_num:", line_num, "time:", int(
+                        1000 * (time.time() - prev_time)), "total_time", int(time.time() - start_time))
 
                 prev_time = time.time()
             prev_line_num = line_num
 
             if triangular:
-                entry_pos = sorted([float(line_parts[p-1]) for p in position_cols])
+                entry_pos = sorted([float(line_parts[p - 1])
+                                    for p in position_cols])
             else:
-                entry_pos = [float(line_parts[p-1]) for p in position_cols]
+                entry_pos = [float(line_parts[p - 1]) for p in position_cols]
 
-            tileset_info['max_value'] = [max(x,y) for x,y in zip(tileset_info['max_value'], value)]
-            tileset_info['min_value'] = [min(x,y) for x,y in zip(tileset_info['min_value'], value)]
+            tileset_info['max_value'] = [
+                max(x, y) for x, y in zip(tileset_info['max_value'], value)]
+            tileset_info['min_value'] = [
+                min(x, y) for x, y in zip(tileset_info['min_value'], value)]
 
             entry_poss = [entry_pos]
             if expand_range is not None:
-                end_pos = int(line_parts[expand_range[1]-1])
+                end_pos = int(line_parts[expand_range[1] - 1])
                 #print("ep", int(entry_pos[0]), end_pos -  int(entry_pos[0]) + 1)
                 for i in range(int(entry_pos[0]), end_pos):
                     new_entry = entry_pos[::]
@@ -123,8 +131,10 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
             # the bin within the tile as well as the tile position
             # place this data point in the highest resolution tile that we can
             for entry_pos in entry_poss:
-                current_bin = tuple([int(ep // (smallest_width // bins_per_dimension)) % bins_per_dimension for ep in entry_pos])
-                current_tile = tuple([int(ep // smallest_width) for ep in entry_pos])
+                current_bin = tuple(
+                    [int(ep // (smallest_width // bins_per_dimension)) % bins_per_dimension for ep in entry_pos])
+                current_tile = tuple([int(ep // smallest_width)
+                                      for ep in entry_pos])
 
                 # we haven't seen this tile before so we save it, in case more data points need to be placed in it
                 if current_tile not in active_tiles[max_zoom]:
@@ -132,12 +142,13 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
 
                 # place the data in the tile
                 tile_contents[max_zoom][current_tile][current_bin] += value
-            
+
             # go through all the tiles and check which ones we're done with
             # start with the max zoom
-            for zoom_level in range(0, max_zoom+1)[::-1]:
-                #print "zoom_level:", zoom_level, "active_tiles length:", len(active_tiles[zoom_level]), "total_time", int(time.time() - start_time)
-                current_tile = tuple([int(ep // (smallest_width * 2 ** (max_zoom - zoom_level)) ) for ep in entry_pos])
+            for zoom_level in range(0, max_zoom + 1)[::-1]:
+                # print "zoom_level:", zoom_level, "active_tiles length:", len(active_tiles[zoom_level]), "total_time", int(time.time() - start_time)
+                current_tile = tuple(
+                    [int(ep // (smallest_width * 2 ** (max_zoom - zoom_level))) for ep in entry_pos])
 
                 # keep track of whether any tiles were finished at the previous level
                 # we can't complete a lower zoom tile unless we complete a higher zoom one
@@ -152,11 +163,11 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
                         tile_value = tile_contents[zoom_level][tile_position]
                         tile_bins = tile_contents[zoom_level][tile_position]
 
-                        #print "tile_bins:", zoom_level, tile_position, tile_bins
+                        # print "tile_bins:", zoom_level, tile_position, tile_bins
 
                         # make sure old requests get saved before we create new ones
                         already_sleeping = False
-                        while q.full(): #q.qsize() > max_queue_size:
+                        while q.full():  # q.qsize() > max_queue_size:
                             if print_status:
                                 if already_sleeping:
                                     sys.stdout.write('.')
@@ -170,16 +181,18 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
                             if print_status:
                                 sys.stdout.write('.\n')
 
-                        q.put((zoom_level, active_tiles[zoom_level][0], tile_bins))
+                        q.put(
+                            (zoom_level, active_tiles[zoom_level][0], tile_bins))
                         '''
                         if zoom_level < max_zoom:
                             print "putting tile"
                         '''
                         finished_tile = True
 
-                        #print "zoom_level:", zoom_level, max_zoom
+                        # print "zoom_level:", zoom_level, max_zoom
                         if zoom_level > 0:
-                            add_to_next_tile(zoom_level, tile_position, tile_bins)
+                            add_to_next_tile(
+                                zoom_level, tile_position, tile_bins)
 
                         # create a lower zoom level tile
 
@@ -214,26 +227,26 @@ def create_tiles(q, first_lines, input_source, position_cols, value_pos, max_zoo
                         break
             '''
 
-    for zoom_level in range(0, max_zoom+1)[::-1]:
+    for zoom_level in range(0, max_zoom + 1)[::-1]:
         for tile_position in active_tiles[zoom_level]:
             tile_value = tile_contents[zoom_level][tile_position]
             tile_bins = tile_contents[zoom_level][tile_position]
 
             q.put((zoom_level, tile_position, tile_bins))
-            
+
             if zoom_level > 0:
                 add_to_next_tile(zoom_level, tile_position, tile_bins)
 
-    tile_saver.save_tile({'tile_id': 'tileset_info', 
+    tile_saver.save_tile({'tile_id': 'tileset_info',
                           'tile_value': tileset_info})
 
-
     while not q.empty():
-        #print "qsize:", q.qsize()
+        # print "qsize:", q.qsize()
         time.sleep(1)
 
     tile_saver.flush()
     return tileset_info
+
 
 def main():
     usage = """
@@ -250,13 +263,17 @@ def main():
     parser.add_argument('--max-pos',
                         help="The maximum range for the tiling")
     parser.add_argument('--assembly', default=None)
-    parser.add_argument('-r', '--resolution', help="The resolution of the data", 
-                        default=None, type=int )
-    parser.add_argument('-k', '--position-cols', help="The position columns (defaults to all but the last, 1-based)", default=None)
-    parser.add_argument('-v', '--value-pos', help='The value column (defaults to the last one, 1-based)', default=None, type=str)
-    parser.add_argument('-z', '--max-zoom', help='The maximum zoom value', default=None, type=int)
+    parser.add_argument('-r', '--resolution', help="The resolution of the data",
+                        default=None, type=int)
+    parser.add_argument('-k', '--position-cols',
+                        help="The position columns (defaults to all but the last, 1-based)", default=None)
+    parser.add_argument(
+        '-v', '--value-pos', help='The value column (defaults to the last one, 1-based)', default=None, type=str)
+    parser.add_argument('-z', '--max-zoom',
+                        help='The maximum zoom value', default=None, type=int)
     parser.add_argument('--expand-range', help='Expand ranges of values')
-    parser.add_argument('--ignore-0', help='Ignore ranges with a zero value', default=False, action='store_true')
+    parser.add_argument('--ignore-0', help='Ignore ranges with a zero value',
+                        default=False, action='store_true')
     parser.add_argument('-b', '--bins-per-dimension', default=1,
                         help="The number of bins to consider in each dimension",
                         type=int)
@@ -289,29 +306,29 @@ def main():
 
     # if specific position columns aren't specified, use all but the last column
     if position_cols is None:
-        position_cols = list(range(1,len(first_line_parts)))
+        position_cols = list(range(1, len(first_line_parts)))
 
     if args.assembly is not None:
         mins = [1 for p in position_cols]
-        maxs = [nc.get_chrominfo(args.assembly).total_length for p in position_cols]
-    else: 
+        maxs = [nc.get_chrominfo(
+            args.assembly).total_length for p in position_cols]
+    else:
         mins = [float(p) for p in args.min_pos.split(',')]
         maxs = [float(p) for p in args.max_pos.split(',')]
 
-    max_width = max([b - a for (a,b) in zip(mins, maxs)])
+    max_width = max([b - a for (a, b) in zip(mins, maxs)])
 
     if args.expand_range is not None:
         expand_range = list(map(int, args.expand_range.split(',')))
     else:
         expand_range = None
 
-
     if args.max_zoom is None:
         # determine the maximum zoom level based on the domain of the data
         # and the resolution
         bins_to_display_at_max_resolution = max_width // args.resolution // args.bins_per_dimension
-        max_max_zoom = math.ceil(math.log(bins_to_display_at_max_resolution) / math.log(2.))
-
+        max_max_zoom = math.ceil(
+            math.log(bins_to_display_at_max_resolution) / math.log(2.))
 
         if max_max_zoom < 0:
             max_max_zoom = 0
@@ -325,11 +342,10 @@ def main():
     smallest_width = args.resolution * args.bins_per_dimension
 
     value_pos = args.value_pos
-    
 
     # if there's not column designated as the value column, use the last column
     if value_pos is None:
-        value_pos = [len(first_line_parts)-1]
+        value_pos = [len(first_line_parts) - 1]
     else:
         value_pos = [int(vp) - 1 for vp in value_pos.split(',')]
 
@@ -347,32 +363,34 @@ def main():
                                         num_dimensions = len(position_cols))
     '''
 
-    print("maxs:", maxs, "max_zoom:", max_zoom, "max_data_in_sparse:", max_data_in_sparse, "url:", args.elasticsearch_url)
+    print("maxs:", maxs, "max_zoom:", max_zoom, "max_data_in_sparse:",
+          max_data_in_sparse, "url:", args.elasticsearch_url)
 
     #bin_counts = col.defaultdict(col.defaultdict(int))
     q = mpr.Queue(maxsize=args.max_queue_size)
 
     tilesaver_processes = []
     finished = mpr.Value('b', False)
-    if args.elasticsearch_url is not None:    
+    if args.elasticsearch_url is not None:
         tile_saver = cst.ElasticSearchTileSaver(max_data_in_sparse,
                                                 args.bins_per_dimension,
                                                 len(position_cols),
                                                 args.elasticsearch_url,
                                                 args.log_file,
                                                 args.print_status,
-                                                initial_value = [0. for vp in value_pos])
+                                                initial_value=[0. for vp in value_pos])
     else:
         tile_saver = cst.ColumnFileTileSaver(max_data_in_sparse,
-                                                args.bins_per_dimension,
-                                                len(position_cols),
-                                                args.columnfile_path,
-                                                args.log_file,
-                                                args.print_status,
-                                                initial_value = [0. for vp in value_pos])
+                                             args.bins_per_dimension,
+                                             len(position_cols),
+                                             args.columnfile_path,
+                                             args.log_file,
+                                             args.print_status,
+                                             initial_value=[0. for vp in value_pos])
 
     for i in range(args.num_threads):
-        p = mpr.Process(target=cst.tile_saver_worker, args=(q, tile_saver, finished))
+        p = mpr.Process(target=cst.tile_saver_worker,
+                        args=(q, tile_saver, finished))
 
         p.daemon = True
         p.start()
@@ -386,16 +404,15 @@ def main():
                     'bins_per_dimension': args.bins_per_dimension,
                     'max_width': max_width}
 
-
-    tile_saver.save_tile({'tile_id': 'tileset_info', 
+    tile_saver.save_tile({'tile_id': 'tileset_info',
                           'tile_value': tileset_info})
     tile_saver.flush()
 
     try:
-        tileset_info = create_tiles(q, [first_line], sys.stdin, position_cols, value_pos, 
-                max_zoom, args.bins_per_dimension, tile_saver, expand_range,
-                args.ignore_0, tileset_info, max_width, args.triangular, args.max_queue_size,
-                print_status=args.print_status)
+        tileset_info = create_tiles(q, [first_line], sys.stdin, position_cols, value_pos,
+                                    max_zoom, args.bins_per_dimension, tile_saver, expand_range,
+                                    args.ignore_0, tileset_info, max_width, args.triangular, args.max_queue_size,
+                                    print_status=args.print_status)
     except KeyboardInterrupt:
         for (ts, p) in tilesaver_processes:
             ts.flush()
@@ -409,12 +426,10 @@ def main():
         p.join()
 
     print("tileset_info:", tileset_info)
-    tile_saver.save_tile({'tile_id': 'tileset_info', 
+    tile_saver.save_tile({'tile_id': 'tileset_info',
                           'tile_value': tileset_info})
     tile_saver.flush()
-         
+
 
 if __name__ == '__main__':
     main()
-
-

--- a/scripts/make_tiles.py
+++ b/scripts/make_tiles.py
@@ -18,116 +18,120 @@ import os.path as op
 import sys
 import time
 
+
 def main():
     usage = """
     python make_tiles.py input_file
 
     Create tiles for all of the entries in the JSON file.
     """
-    num_args= 1
+    num_args = 1
     parser = argparse.ArgumentParser()
 
     #parser.add_argument('-o', '--options', dest='some_option', default='yo', help="Place holder for a real option", type='str')
     #parser.add_argument('-u', '--useless', dest='uselesss', default=False, action='store_true', help='Another useless option')
     parser.add_argument('input_file')
-    parser.add_argument('-b', '--bins-per-dimension', 
+    parser.add_argument('-b', '--bins-per-dimension',
                         help='The number of bins to divide the data into',
                         default=1,
                         type=int)
     parser.add_argument('--use-spark', default=False, action='store_true',
                         help='Use spark to distribute the workload')
 
-    parser.add_argument('-r', '--resolution', 
+    parser.add_argument('-r', '--resolution',
                         help='The resolution of the data (applies only to matrix data)',
                         type=int)
 
-    parser.add_argument('--importance', action='store_true', help='Create tiles by importance') 
+    parser.add_argument('--importance', action='store_true',
+                        help='Create tiles by importance')
 
     parser.add_argument('-i', '--importance-field', dest='importance_field', default='importance_field',
-            help='The field in each JSON entry that indicates how important that entry is',
-            type=str)
+                        help='The field in each JSON entry that indicates how important that entry is',
+                        type=str)
     parser.add_argument('-v', '--value', dest='value_field', default='count',
-            help='The that has the value of each point. Used for aggregation and display')
+                        help='The that has the value of each point. Used for aggregation and display')
 
     group = parser.add_mutually_exclusive_group()
 
     group.add_argument('-p', '--position', dest='position', default='position',
-            help='Where this entry would be placed on the x axis',
-            type=str)
-    group.add_argument('-s', '--sort-by', 
-            default=None,
-            help='Sort by a field and use as the position') 
+                       help='Where this entry would be placed on the x axis',
+                       type=str)
+    group.add_argument('-s', '--sort-by',
+                       default=None,
+                       help='Sort by a field and use as the position')
 
     parser.add_argument('--end-position', default=None,
-                        help = "Use a field to indicate the end of a particular element so that it appears in all tiles that intersect it")
+                        help="Use a field to indicate the end of a particular element so that it appears in all tiles that intersect it")
     parser.add_argument('-e', '--max-entries-per-tile', dest='max_entries_per_tile', default=15,
-        help='The maximum number of entries that can be displayed on a single tile',
-        type=int)
-    parser.add_argument('-c', '--column-names', dest='column_names', default=None)
-    parser.add_argument('-m', '--max-zoom', dest='max_zoom', 
-            help='The maximum zoom level', type=int, required=True)
+                        help='The maximum number of entries that can be displayed on a single tile',
+                        type=int)
+    parser.add_argument('-c', '--column-names',
+                        dest='column_names', default=None)
+    parser.add_argument('-m', '--max-zoom', dest='max_zoom',
+                        help='The maximum zoom level', type=int, required=True)
     parser.add_argument('--min-pos', dest='min_pos', default=None,
-            help='The minimum x position', type=float)
+                        help='The minimum x position', type=float)
     parser.add_argument('--max-pos', dest='max_pos', default=None,
-            help='The maximum x position', type=float)
+                        help='The maximum x position', type=float)
     parser.add_argument('--assembly', default=None)
 
-    parser.add_argument('--min-value', 
-            help='The field which will be used to determinethe minimum value for any data point', 
-            default='min_y')
-    parser.add_argument('--max-value', 
-            help='The field which will be used to determine the maximum value for any data point', 
-            default='max_y')
+    parser.add_argument('--min-value',
+                        help='The field which will be used to determinethe minimum value for any data point',
+                        default='min_y')
+    parser.add_argument('--max-value',
+                        help='The field which will be used to determine the maximum value for any data point',
+                        default='max_y')
     parser.add_argument('--range',
-            help="Use two columns to create a range (i.e. pos1,pos2",
-            default=None)
+                        help="Use two columns to create a range (i.e. pos1,pos2",
+                        default=None)
     parser.add_argument('--range-except-0',
-            help="Don't expand rows which have values less than 0",
-            default=None)
-    parser.add_argument('--gzip', help='Compress the output JSON files using gzip', 
-            action='store_true')
-    parser.add_argument('--output-format', 
-            help='The format for the output matrix, can be either "dense" or "sparse"',
-            default='sparse')
+                        help="Don't expand rows which have values less than 0",
+                        default=None)
+    parser.add_argument('--gzip', help='Compress the output JSON files using gzip',
+                        action='store_true')
+    parser.add_argument('--output-format',
+                        help='The format for the output matrix, can be either "dense" or "sparse"',
+                        default='sparse')
     parser.add_argument('--add-uuid',
-            help='Add a uuid to each element',
-            action='store_true',
-            default=False)
+                        help='Add a uuid to each element',
+                        action='store_true',
+                        default=False)
     parser.add_argument('--reverse-importance',
-            help='Reverse the ordering of the importance',
-            action='store_true',
-            default=False)
+                        help='Reverse the ordering of the importance',
+                        action='store_true',
+                        default=False)
 
     output_group = parser.add_mutually_exclusive_group(required=True)
 
     output_group.add_argument('--elasticsearch-path',
-            help='Send the output to an elasticsearch instance',
-            default=None)
+                              help='Send the output to an elasticsearch instance',
+                              default=None)
     output_group.add_argument('-o', '--output-dir', help='The directory to place the tiles',
-            default=None)
-    
-    parser.add_argument('--delimiter',
-            help="The delimiter separating the different columns in the input files",
-            default=None)
+                              default=None)
 
-    parser.add_argument('--elasticsearch-nodes', 
-            help='Specify elasticsearch nodes to push the completions to',
-            default=None)
+    parser.add_argument('--delimiter',
+                        help="The delimiter separating the different columns in the input files",
+                        default=None)
+
+    parser.add_argument('--elasticsearch-nodes',
+                        help='Specify elasticsearch nodes to push the completions to',
+                        default=None)
     parser.add_argument('--elasticsearch-index',
-            help="The index to place the results in",
-            default='test')
+                        help="The index to place the results in",
+                        default='test')
     parser.add_argument('--elasticsearch-doctype',
-            help="The type of document to index",
-            default="autocomplete")
+                        help="The type of document to index",
+                        default="autocomplete")
     parser.add_argument('--print-status',
-            action="store_true",
-            help="Print status messages")
+                        action="store_true",
+                        help="Print status messages")
 
     args = parser.parse_args()
 
     if not args.importance:
         if args.output_format not in ['sparse', 'dense']:
-            print('ERROR: The output format must be one of "dense" or "sparse"', file=sys.stderr)
+            print(
+                'ERROR: The output format must be one of "dense" or "sparse"', file=sys.stderr)
 
     dim_names = args.position.split(',')
     position_cols = dim_names
@@ -146,98 +150,99 @@ def main():
 
     if args.assembly is not None:
         mins = [1 for p in position_cols]
-        maxs = [nc.get_chrominfo(args.assembly).total_length for p in position_cols]
-    else: 
+        maxs = [nc.get_chrominfo(
+            args.assembly).total_length for p in position_cols]
+    else:
         mins = [float(p) for p in args.min_pos.split(',')]
         maxs = [float(p) for p in args.max_pos.split(',')]
 
-    max_width = max([b - a for (a,b) in zip(mins, maxs)])
+    max_width = max([b - a for (a, b) in zip(mins, maxs)])
 
     print("start time:", strftime("%Y-%m-%d %H:%M:%S", gmtime()))
     entries = cti.load_entries_from_file(sc, args.input_file, args.column_names,
-            delimiter=args.delimiter,
-            elasticsearch_path=args.elasticsearch_path)
+                                         delimiter=args.delimiter,
+                                         elasticsearch_path=args.elasticsearch_path)
     print("load entries time:", strftime("%Y-%m-%d %H:%M:%S", gmtime()))
 
     if args.range is not None:
         # if a pair of columns specifies a range of values, then create multiple
         # entries for each value within that range (e.g. bed files)
         range_cols = args.range.split(',')
-        entries = entries.flatMap(lambda x: cti.expand_range(x, *range_cols, range_except_0 = args.range_except_0))
+        entries = entries.flatMap(lambda x: cti.expand_range(
+            x, *range_cols, range_except_0=args.range_except_0))
 
     if args.importance:
         # Data will be aggregated by importance. Only more "important" pieces of information will
         # be passed onto the lower resolution tiles if they are too crowded
-        tileset = cti.make_tiles_by_importance(sc, entries, dim_names=args.position.split(','), 
-                end_dim_names = args.end_position.split(','),
-                max_zoom=args.max_zoom, 
-                importance_field=args.importance_field,
-                output_dir=args.output_dir,
-                max_entries_per_tile = args.max_entries_per_tile,
-                gzip_output=args.gzip, add_uuid=args.add_uuid,
-                reverse_importance=args.reverse_importance, adapt_zoom=False,
-                mins=mins, maxs=maxs)
+        tileset = cti.make_tiles_by_importance(sc, entries, dim_names=args.position.split(','),
+                                               end_dim_names=args.end_position.split(
+                                                   ','),
+                                               max_zoom=args.max_zoom,
+                                               importance_field=args.importance_field,
+                                               output_dir=args.output_dir,
+                                               max_entries_per_tile=args.max_entries_per_tile,
+                                               gzip_output=args.gzip, add_uuid=args.add_uuid,
+                                               reverse_importance=args.reverse_importance, adapt_zoom=False,
+                                               mins=mins, maxs=maxs)
     else:
         # Data will be aggregated by binning. This means that it two adjacent bins should be able
         # to be reduced into one using some function (i.e. 'sum', 'min', 'max')
-        tileset = cti.make_tiles_by_binning(sc, entries, args.position.split(','), 
-                args.max_zoom, args.value_field, args.importance_field,
-                bins_per_dimension=args.bins_per_dimension,
-                resolution=args.resolution)
+        tileset = cti.make_tiles_by_binning(sc, entries, args.position.split(','),
+                                            args.max_zoom, args.value_field, args.importance_field,
+                                            bins_per_dimension=args.bins_per_dimension,
+                                            resolution=args.resolution)
 
     all_tiles = tileset['tiles']
 
     if args.elasticsearch_nodes is not None:
         # save the tiles to an elasticsearch database
         save_tile_to_elasticsearch = ft.partial(cst.save_tile_to_elasticsearch,
-            elasticsearch_nodes = args.elasticsearch_nodes,
-            elasticsearch_path = args.elasticsearch_path,
-            print_status = args.print_status)
+                                                elasticsearch_nodes=args.elasticsearch_nodes,
+                                                elasticsearch_path=args.elasticsearch_path,
+                                                print_status=args.print_status)
 
-        (all_tiles.map(lambda x: {"tile_id": ".".join(map(str,x[0])), "tile_value": x[1]})
-                 .foreachPartition(save_tile_to_elasticsearch))
+        (all_tiles.map(lambda x: {"tile_id": ".".join(map(str, x[0])), "tile_value": x[1]})
+         .foreachPartition(save_tile_to_elasticsearch))
 
         dataset_info = cdd.describe_dataset(sys.argv, args)
         print("saving tileset_info to:", args.elasticsearch_path)
-        (sc.parallelize([{"tile_value": tileset['tileset_info'], 
+        (sc.parallelize([{"tile_value": tileset['tileset_info'],
                           "tile_id": "tileset_info"}])
-           .foreachPartition(save_tile_to_elasticsearch))
+         .foreachPartition(save_tile_to_elasticsearch))
 
         (sc.parallelize([{"tile_value": dataset_info,
                           "tile_id": "dataset_info"}])
-           .foreachPartition(save_tile_to_elasticsearch))
+         .foreachPartition(save_tile_to_elasticsearch))
 
         if 'histogram' in tileset:
-            histogram_rdd = sc.parallelize([{"tile_value": tileset['histogram'], 
+            histogram_rdd = sc.parallelize([{"tile_value": tileset['histogram'],
                                              "tile_id": "histogram"}])
 
             histogram_rdd.foreachPartition(save_tile_to_elasticsearch)
     else:
         # dump tiles to a directory structure
         all_tiles.foreach(ft.partial(cst.save_tile,
-                                     output_dir=args.output_dir, 
+                                     output_dir=args.output_dir,
                                      gzip_output=args.gzip))
 
         dataset_info = cdd.describe_dataset(sys.argv, args)
 
         with open(op.join(args.output_dir, 'dataset_info'), 'w') as f:
             json.dump({"_source": {"tile_id": "dataset_info",
-                                   "tile_value": dataset_info}}, 
+                                   "tile_value": dataset_info}},
                       f, indent=2)
 
         with open(op.join(args.output_dir, 'tileset_info'), 'w') as f:
             json.dump({"_source": {"tile_id": "tileset_info",
-                                   "tile_value": tileset['tileset_info']}}, 
+                                   "tile_value": tileset['tileset_info']}},
                       f, indent=2)
 
         if 'histogram' in tileset:
             with open(op.join(args.output_dir, 'value_histogram'), 'w') as f:
-                json.dump({"_source": { "tile_id": "histogram",
-                                        "tile_value": tileset['histogram']}}, 
+                json.dump({"_source": {"tile_id": "histogram",
+                                       "tile_value": tileset['histogram']}},
                           f, indent=2)
 
 
 if __name__ == '__main__':
     main()
-
-

--- a/scripts/process_file.py
+++ b/scripts/process_file.py
@@ -6,6 +6,7 @@ import subprocess as sp
 import sys
 import tempfile as tf
 
+
 def main():
     usage = """
     python make_tiles.py input_file
@@ -31,32 +32,32 @@ def main():
         tempfile1 = tf.TemporaryFile()
 
         p05 = sp.Popen(['bigWigToBedGraph', args.filepath, '/dev/fd/1'],
-                        stdout = tempfile1)
+                       stdout=tempfile1)
         p05.wait()
         tempfile1.seek(0)
 
-        p0 = sp.Popen(['pv', '-f', '-'], 
-                        stdin=tempfile1,
-                        stdout=sp.PIPE, 
-                        stderr=sp.PIPE, 
-                        universal_newlines=True)
+        p0 = sp.Popen(['pv', '-f', '-'],
+                      stdin=tempfile1,
+                      stdout=sp.PIPE,
+                      stderr=sp.PIPE,
+                      universal_newlines=True)
         pn = p0
     elif args.type == 'bedgraph':
-        p0 = sp.Popen(['pv', '-f', args.filepath], 
-                        stdout=sp.PIPE, 
-                        stderr=sp.PIPE, 
-                        universal_newlines=True)
+        p0 = sp.Popen(['pv', '-f', args.filepath],
+                      stdout=sp.PIPE,
+                      stderr=sp.PIPE,
+                      universal_newlines=True)
         pn = p0
 
-    p1 = sp.Popen(["awk", "{print $1, $2, $1, $3, $4 }"],  
-                    stdin = pn.stdout,
-                   stdout=sp.PIPE)
+    p1 = sp.Popen(["awk", "{print $1, $2, $1, $3, $4 }"],
+                  stdin=pn.stdout,
+                  stdout=sp.PIPE)
     p2 = sp.Popen(['chr_pos_to_genome_pos.py', '-e 5', '-a', '{}'.format(args.assembly)],
-                    stdin = p1.stdout,
-                    stdout=sp.PIPE)
+                  stdin=p1.stdout,
+                  stdout=sp.PIPE)
     p3 = sp.Popen(['sort', '-k1,1n', '-k2,2n', '-'],
-                    stdin = p2.stdout, 
-                    stdout=tempfile)
+                  stdin=p2.stdout,
+                  stdout=tempfile)
 
     for line in iter(p0.stderr.readline, ""):
         print("line:", line.strip())
@@ -71,12 +72,12 @@ def main():
     tempfile.seek(0)
 
     p35 = sp.Popen(['pv', '-f', '-'],
-                    stdin = tempfile,
-                    stdout = sp.PIPE,
-                    stderr = sp.PIPE,
-                    universal_newlines=True)
+                   stdin=tempfile,
+                   stdout=sp.PIPE,
+                   stderr=sp.PIPE,
+                   universal_newlines=True)
     p4 = sp.Popen(['gzip'],
-                    stdin = p35.stdout, stdout=outfile)
+                  stdin=p35.stdout, stdout=outfile)
     for line in iter(p35.stderr.readline, ""):
         print("line:", line.strip())
 
@@ -84,6 +85,7 @@ def main():
     p4.wait()
 
     print("filedir:", filedir)
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/pyprof.sh
+++ b/scripts/pyprof.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
-#https://github.com/martinxyz/config/blob/master/scripts/pyprof
-set -e # exit on error
-rm -f profile.png profile.dat
-python -m cProfile -o profile.dat $@
-gprof2dot.py -f pstats profile.dat | dot -Tpng -o profile.png
+# https://github.com/martinxyz/config/blob/master/scripts/pyprof
+set - e  # exit on error
+rm - f profile.png profile.dat
+python - m cProfile - o profile.dat $@
+gprof2dot.py - f pstats profile.dat | dot - Tpng - o profile.png
 open profile.png

--- a/scripts/temp.py
+++ b/scripts/temp.py
@@ -1,10 +1,9 @@
-import numpy as np
-import pyximport; 
-pyximport.install( setup_args= {"include_dirs":np.get_include()})
-
-import clodius.fast
-
 import time
+import clodius.fast
+import numpy as np
+import pyximport
+pyximport.install(setup_args={"include_dirs": np.get_include()})
+
 
 x = np.array(range(2**16))
 t1 = time.time()

--- a/scripts/test_1d.py
+++ b/scripts/test_1d.py
@@ -25,35 +25,34 @@ def main():
 
     parser.add_argument('-n', '--num-trials', default=1, type=int)
     #parser.add_argument('argument', nargs=1)
-    #parser.add_argument('-o', '--options', default='yo',
+    # parser.add_argument('-o', '--options', default='yo',
     #					 help="Some option", type='str')
-    #parser.add_argument('-u', '--useless', action='store_true', 
+    # parser.add_argument('-u', '--useless', action='store_true',
     #					 help='Another useless option')
 
     args = parser.parse_args()
 
     f = h5py.File(args.filepath, 'r')
-   
+
     t1 = time.time()
 
     if args.num_trials < 1:
         print("The number of trials needs to be greater than 0", file=sys.stderr)
 
     if args.x is not None and args.z is not None:
-        d =  ch.get_data(f, args.z, args.x)
+        d = ch.get_data(f, args.z, args.x)
         print("z:", args.z, "x:", args.x, "len:", len(d), d)
         return
 
-
     for i in range(args.num_trials):
-        z  = random.randint(0, int(f['meta'].attrs['max-zoom']))
+        z = random.randint(0, int(f['meta'].attrs['max-zoom']))
         x = random.randint(0, 2**z)
 
-        d =  ch.get_data(f, z, x)
+        d = ch.get_data(f, z, x)
         print("z:", z, "x:", x, "len:", len(d), d)
         #d =  ch.get_data(f, 1, 1)
 
-        #print "z:", z, "x:", x
+        # print "z:", z, "x:", x
     t2 = time.time()
     print("avg time:", (t2 - t1) / args.num_trials)
 
@@ -70,6 +69,7 @@ def main():
 
     print "1953:", f['values_8'][1952]
     '''
+
 
 if __name__ == '__main__':
     main()

--- a/scripts/tile_1d.py
+++ b/scripts/tile_1d.py
@@ -10,11 +10,13 @@ import sys
 import time
 import argparse
 
+
 def reduce_data(data_array):
     s = set(data_array)
-    lookup_table = dict([(x,i) for i,x in enumerate(s)])
+    lookup_table = dict([(x, i) for i, x in enumerate(s)])
 
-    print("len lookup_table:", len(lookup_table), "len data_array:", len(data_array))
+    print("len lookup_table:", len(lookup_table),
+          "len data_array:", len(data_array))
     t1 = time.time()
     new_data = [lookup_table[d] for d in data_array]
     t2 = time.time()
@@ -35,9 +37,9 @@ def main():
     parser.add_argument('-z', '--zoom-step', default=8, type=int)
     parser.add_argument('-t', '--tile-size', default=1024, type=int)
     parser.add_argument('-o', '--output-file', default='/tmp/tmp.hdf5')
-    #parser.add_argument('-o', '--options', default='yo',
+    # parser.add_argument('-o', '--options', default='yo',
     #					 help="Some option", type='str')
-    #parser.add_argument('-u', '--useless', action='store_true',
+    # parser.add_argument('-u', '--useless', action='store_true',
     #					 help='Another useless option')
     args = parser.parse_args()
     last_end = 0
@@ -60,7 +62,8 @@ def main():
     positions = []   # store where we are at the current dataset
     data_buffers = [[]]
     while hum_size / 2 ** z > tile_size:
-        dsets += [f.create_dataset('values_' + str(z), (hum_size / 2 ** z,), dtype='f',compression='gzip')]
+        dsets += [f.create_dataset('values_' + str(z),
+                                   (hum_size / 2 ** z,), dtype='f', compression='gzip')]
         data_buffers += [[]]
         positions += [0]
         z += args.zoom_step
@@ -70,10 +73,10 @@ def main():
     d.attrs['max-length'] = hum_size
     d.attrs['assembly'] = 'hg19'
     d.attrs['tile-size'] = tile_size
-    d.attrs['max-zoom'] = math.ceil(math.log(d.attrs['max-length'] / tile_size) / math.log(2))
+    d.attrs['max-zoom'] = math.ceil(
+        math.log(d.attrs['max-length'] / tile_size) / math.log(2))
 
     print("max_zoom:", d.attrs['max-zoom'])
-
 
     if args.filepath is None:
         print("Waiting for input...")
@@ -94,13 +97,14 @@ def main():
                 # get the current chunk and store it
                 print("curr_zoom:", curr_zoom)
                 curr_chunk = np.array(data_buffers[curr_zoom][:chunk_size])
-                dsets[curr_zoom][positions[curr_zoom]:positions[curr_zoom]+chunk_size] = curr_chunk
+                dsets[curr_zoom][positions[curr_zoom]                                 :positions[curr_zoom] + chunk_size] = curr_chunk
 
                 # aggregate and store aggregated values in the next zoom_level's data
-                data_buffers[curr_zoom+1] += list(ct.aggregate(curr_chunk, 2 ** args.zoom_step))
+                data_buffers[curr_zoom +
+                             1] += list(ct.aggregate(curr_chunk, 2 ** args.zoom_step))
                 data_buffers[curr_zoom] = data_buffers[curr_zoom][chunk_size:]
                 positions[curr_zoom] += chunk_size
-                data = data_buffers[curr_zoom+1]
+                data = data_buffers[curr_zoom + 1]
                 curr_zoom += 1
 
         # store the remaining data
@@ -110,16 +114,18 @@ def main():
             # get the current chunk and store it
             chunk_size = len(data_buffers[curr_zoom])
             curr_chunk = np.array(data_buffers[curr_zoom][:chunk_size])
-            dsets[curr_zoom][positions[curr_zoom]:positions[curr_zoom]+chunk_size] = curr_chunk
+            dsets[curr_zoom][positions[curr_zoom]                             :positions[curr_zoom] + chunk_size] = curr_chunk
 
-            print("curr_zoom:", curr_zoom, "position:", positions[curr_zoom] + len(curr_chunk))
+            print("curr_zoom:", curr_zoom, "position:",
+                  positions[curr_zoom] + len(curr_chunk))
             print("len:", [len(d) for d in data_buffers])
 
             # aggregate and store aggregated values in the next zoom_level's data
-            data_buffers[curr_zoom+1] += list(ct.aggregate(curr_chunk, 2 ** args.zoom_step))
+            data_buffers[curr_zoom +
+                         1] += list(ct.aggregate(curr_chunk, 2 ** args.zoom_step))
             data_buffers[curr_zoom] = data_buffers[curr_zoom][chunk_size:]
             positions[curr_zoom] += chunk_size
-            data = data_buffers[curr_zoom+1]
+            data = data_buffers[curr_zoom + 1]
             curr_zoom += 1
 
             # we've created enough tile levels to cover the entire maximum width
@@ -159,9 +165,8 @@ def main():
     print "len(data):", len(data)
     '''
 
-    #print data
+    # print data
+
 
 if __name__ == '__main__':
     main()
-
-

--- a/test/bedpe_test.py
+++ b/test/bedpe_test.py
@@ -12,16 +12,17 @@ sys.path.append("scripts")
 
 testdir = op.realpath(op.dirname(__file__))
 
+
 def test_clodius_aggregate_bedpe():
     input_file = op.join(testdir, 'sample_data', 'isidro.bedpe')
     output_file = '/tmp/isidro.bed2ddb'
 
     cca._bedpe(input_file, output_file, 'b37',
-            importance_column=None,
-            chromosome=None,
-            max_per_tile=100,
-            tile_size=1024,
-            has_header=True)
+               importance_column=None,
+               chromosome=None,
+               max_per_tile=100,
+               tile_size=1024,
+               has_header=True)
 
     """
     runner = clt.CliRunner()

--- a/test/fpark_test.py
+++ b/test/fpark_test.py
@@ -2,19 +2,24 @@ import sys
 
 import clodius.fpark as fp
 
-def test_map():
-    a = fp.FakeSparkContext.parallelize([1,2,3,4])
 
-    b = a.map(lambda x: x+1)
+def test_map():
+    a = fp.FakeSparkContext.parallelize([1, 2, 3, 4])
+
+    b = a.map(lambda x: x + 1)
     assert(b.collect()[0] == 2)
 
+
 def test_group_by_key():
-    a = fp.FakeSparkContext.parallelize([(1,2),(1,3),(1,4),(2,5),(2,6)])
+    a = fp.FakeSparkContext.parallelize(
+        [(1, 2), (1, 3), (1, 4), (2, 5), (2, 6)])
 
     b = a.groupByKey()
 
+
 def test_textFile():
-    a = fp.FakeSparkContext.textFile('test/sample_data/piecewise-file/part-00000')
+    a = fp.FakeSparkContext.textFile(
+        'test/sample_data/piecewise-file/part-00000')
     parts = a.collect()
     assert(len(parts) == 2)
 

--- a/test/tile_2d_bedfile_test.py
+++ b/test/tile_2d_bedfile_test.py
@@ -4,6 +4,7 @@ import clodius.db_tiles as cdt
 import h5py
 import sqlite3
 
+
 def test_get_tileset_info():
     filename = 'test/sample_data/arrowhead_domains_short.txt.multires.db'
     t = cdt.get_tileset_info(filename)
@@ -13,9 +14,10 @@ def test_get_tileset_info():
     assert(t['max_width'] > 4000000000)
     assert(t['max_width'] < 5000000000)
 
+
 def test_get_tiles():
     filename = 'test/sample_data/arrowhead_domains_short.txt.multires.db'
 
-    tiles = cdt.get_2d_tiles(filename, 0,0,0, numx=1, numy=1)
+    tiles = cdt.get_2d_tiles(filename, 0, 0, 0, numx=1, numy=1)
 
     #print("tiles:", tiles)


### PR DESCRIPTION
## Description

What was changed in this pull request?
- Add a list of all the python files to the flake8 ignore
- Auto-correct scripts and tests that have not been touched in a year.
- Remove them from the list I just added.
- Remove most of the whilespace rules from the ignore list, so they will be enforced on new files, and those that have been cleaned.

Why is it necessary?
- I'm imagining we do a first pass to clean up the whitespace, taking the files in small batches, and then after that a second pass where we can get to the more useful errors.

(If you actually don't like one of these rules, we can ignore it, but I'd think the default should be to try to apply them all.)

## Checklist

- [ ] Unit tests added or updated
- [ ] Updated CHANGELOG.md
