### PR TITLE
Ignore sample_data created by tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ clodius/*.c
 docs/_templates
 docs/_static
 docs/_build
+test/sample_data


### PR DESCRIPTION
## Description

What was changed in this pull request?
- gitignore test/sample_data

Why is it necessary?
- Tests create this and clean it up, but if I hit ctrl-c, it is left in place. We wouldn't want junk to be committed.

## Checklist

- [ ] Unit tests added or updated
- [ ] Updated CHANGELOG.md
