### PR TITLE
Mccalluc/mrmatrix col row labels

### DIFF
--- a/scripts/tsv_to_mrmatrix.py
+++ b/scripts/tsv_to_mrmatrix.py
@@ -40,16 +40,15 @@ def coarsen(f, tile_size=256):
 
 
 def parse(input_handle, output_hdf5, height, width,
-          delimiter, first_n, is_square, is_labelled):
+          delimiter, first_n, is_labelled):
     reader = csv.reader(input_handle, delimiter=delimiter)
     if is_labelled:
         first_row = next(reader)
-        labels = first_row[1:(first_n + 1) if first_n else None]
-        if is_square:
-            output_hdf5.create_dataset(
-                'labels',
-                data=np.array(labels, dtype=h5py.special_dtype(vlen=str)),
-                compression='lzf')
+        col_labels = first_row[1:(first_n + 1) if first_n else None]
+        output_hdf5.create_dataset(
+            'col_labels',
+            data=np.array(col_labels, dtype=h5py.special_dtype(vlen=str)),
+            compression='lzf')
         # TODO: Handle non-square labels
         # https://github.com/higlass/clodius/issues/68
 
@@ -127,8 +126,6 @@ def main():
                         metavar='D', help='Delimiter; defaults to tab')
     parser.add_argument('-n', '--first-n', type=int, default=None, metavar='N',
                         help='Only read first N columns from first N rows')
-    parser.add_argument('-s', '--square', action='store_true',
-                        help='Row labels are assumed to match column labels')
     parser.add_argument('-l', '--labelled', action='store_true',
                         help='TSV Matrix has column and row labels')
     args = parser.parse_args()
@@ -146,7 +143,6 @@ def main():
           height=height, width=width,
           delimiter=args.delimiter,
           first_n=args.first_n,
-          is_square=args.square,
           is_labelled=args.labelled)
 
     f = h5py.File(args.output_file, 'r')

--- a/scripts/tsv_to_mrmatrix.py
+++ b/scripts/tsv_to_mrmatrix.py
@@ -67,8 +67,14 @@ def parse(input_handle, output_hdf5, height, width,
 
     start_time = time.time()
     counter = 0
+    row_labels = []
     for row in reader:
-        x = np.array([float(p) for p in row[1 if is_labelled else None:]])
+        if is_labelled:
+            offset = 1
+            row_labels.append(row[0])
+        else:
+            offset = 0
+        x = np.array([float(p) for p in row[offset:]])
         ds[counter, :len(x)] = x
 
         counter += 1
@@ -82,6 +88,11 @@ def parse(input_handle, output_hdf5, height, width,
         print("counter:", counter, "sum(x):", sum(x),
               "time remaining: {:d} seconds".format(int(time_remaining)))
 
+    if is_labelled:
+        output_hdf5.create_dataset(
+            'row_labels',
+            data=np.array(row_labels, dtype=h5py.special_dtype(vlen=str)),
+            compression='lzf')
     coarsen(output_hdf5)
     output_hdf5.close()
 

--- a/test/tsv_to_mrmatrix_test.py
+++ b/test/tsv_to_mrmatrix_test.py
@@ -132,12 +132,11 @@ class ParseTest(unittest.TestCase):
             height = get_height(csv_path)
             width = get_width(csv_path, is_labelled=True)
             parse(csv_handle, hdf5_write_handle, height, width,
-                  delimiter='\t', first_n=None, is_square=True,
-                  is_labelled=True)
+                  delimiter='\t', first_n=None, is_labelled=True)
 
             hdf5 = h5py.File(hdf5_path, 'r')
-            self.assertEqual(list(hdf5.keys()), ['labels', 'resolutions'])
-            self.assertEqual(list(hdf5['labels']), labels[1:])
+            self.assertEqual(list(hdf5.keys()), ['col_labels', 'resolutions'])
+            self.assertEqual(list(hdf5['col_labels']), labels[1:])
 
             self.assertEqual(list(hdf5['resolutions'].keys()), ['1', '2'])
 
@@ -168,7 +167,7 @@ class ParseTest(unittest.TestCase):
             # https://github.com/higlass/clodius/issues/62
 
     def _assert_unlabelled_roundtrip_lt_256(
-            self, matrix, delimiter, is_square):
+            self, matrix, delimiter):
         with TemporaryDirectory() as tmp_dir:
             csv_path = tmp_dir + '/tmp.csv'
             with open(csv_path, 'w', newline='') as csv_file:
@@ -186,7 +185,7 @@ class ParseTest(unittest.TestCase):
             width = get_width(csv_path, is_labelled=is_labelled)
             parse(csv_handle, hdf5_write_handle, height, width,
                   first_n=None, is_labelled=is_labelled,
-                  delimiter=delimiter, is_square=is_square)
+                  delimiter=delimiter)
 
             hdf5 = h5py.File(hdf5_path, 'r')
             self.assertEqual(list(hdf5.keys()), ['resolutions'])
@@ -202,24 +201,15 @@ class ParseTest(unittest.TestCase):
                 matrix
             )
 
-    def test_unlabelled_csv_is_square_true(self):
+    def test_unlabelled_csv(self):
         self._assert_unlabelled_roundtrip_lt_256(
             matrix=[[x + y for x in range(4)] for y in range(4)],
-            delimiter=',',
-            is_square=True
-        )
-
-    def test_unlabelled_tsv_is_square_false(self):
-        self._assert_unlabelled_roundtrip_lt_256(
-            matrix=[[x + y for x in range(4)] for y in range(4)],
-            delimiter='\t',
-            is_square=False
+            delimiter=','
         )
 
     def _assert_unlabelled_roundtrip_1024(
             self, matrix, first_row=None, first_col=None, first_n=None):
         delimiter = '\t'
-        is_square = False
         with TemporaryDirectory() as tmp_dir:
             csv_path = tmp_dir + '/tmp.csv'
             with open(csv_path, 'w', newline='') as csv_file:
@@ -237,7 +227,7 @@ class ParseTest(unittest.TestCase):
             width = get_width(csv_path, is_labelled=is_labelled)
             parse(csv_handle, hdf5_write_handle, height, width,
                   first_n=first_n, is_labelled=is_labelled,
-                  delimiter=delimiter, is_square=is_square)
+                  delimiter=delimiter)
 
             hdf5 = h5py.File(hdf5_path, 'r')
             self.assertEqual(list(hdf5.keys()), ['resolutions'])

--- a/test/tsv_to_mrmatrix_test.py
+++ b/test/tsv_to_mrmatrix_test.py
@@ -115,8 +115,8 @@ class ParseTest(unittest.TestCase):
             with open(csv_path, 'w', newline='') as csv_file:
                 writer = csv.writer(csv_file, delimiter='\t')
                 # header:
-                labels = ['col-{}'.format(x) for x in range(513)]
-                writer.writerow(labels)
+                col_labels = ['col-{}'.format(x) for x in range(513)]
+                writer.writerow(col_labels)
                 # body:
                 for y in range(0, 3):
                     writer.writerow(['row-{}'.format(y)] + [0] * 512)
@@ -135,8 +135,9 @@ class ParseTest(unittest.TestCase):
                   delimiter='\t', first_n=None, is_labelled=True)
 
             hdf5 = h5py.File(hdf5_path, 'r')
-            self.assertEqual(list(hdf5.keys()), ['col_labels', 'resolutions'])
-            self.assertEqual(list(hdf5['col_labels']), labels[1:])
+            self.assertEqual(list(hdf5.keys()), ['col_labels', 'resolutions', 'row_labels'])
+            self.assertEqual(list(hdf5['col_labels']), col_labels[1:])
+            self.assertEqual(list(hdf5['row_labels']), ['row-{}'.format(r) for r in range(9)])
 
             self.assertEqual(list(hdf5['resolutions'].keys()), ['1', '2'])
 

--- a/test/tsv_to_mrmatrix_test.py
+++ b/test/tsv_to_mrmatrix_test.py
@@ -135,9 +135,12 @@ class ParseTest(unittest.TestCase):
                   delimiter='\t', first_n=None, is_labelled=True)
 
             hdf5 = h5py.File(hdf5_path, 'r')
-            self.assertEqual(list(hdf5.keys()), ['col_labels', 'resolutions', 'row_labels'])
-            self.assertEqual(list(hdf5['col_labels']), col_labels[1:])
-            self.assertEqual(list(hdf5['row_labels']), ['row-{}'.format(r) for r in range(9)])
+            self.assertEqual(list(hdf5.keys()),
+                             ['col_labels', 'resolutions', 'row_labels'])
+            self.assertEqual(list(hdf5['col_labels']),
+                             col_labels[1:])
+            self.assertEqual(list(hdf5['row_labels']),
+                             ['row-{}'.format(r) for r in range(9)])
 
             self.assertEqual(list(hdf5['resolutions'].keys()), ['1', '2'])
 


### PR DESCRIPTION
## Description

What was changed in this pull request?
- `row_labels` now included as part of the hdf5.

Why is it necessary?
- We agreed that recording both the column and row labels is better than having special treatment for symmetric matrices.

Fixes  #68

## Checklist

- [ ] Unit tests added or updated
- [ ] Updated CHANGELOG.md
