### PR TITLE
Add an option to limit the maximum bam tile width

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+v0.11.1
+
+- Added `max_tile_width` parameter to ct.bam.tiles() so that users can set a
+  limit on how large of a region data is returned for
+
 v0.11.0
 
 - Added bamfile support

--- a/clodius/tiles/bam.py
+++ b/clodius/tiles/bam.py
@@ -132,7 +132,7 @@ def tileset_info(filename):
     return tileset_info
 
 
-def tiles(filename, tile_ids, index_filename=None):
+def tiles(filename, tile_ids, index_filename=None, max_tile_width=None):
     '''
     Generate tiles from a bigwig file.
 
@@ -145,6 +145,9 @@ def tiles(filename, tile_ids, index_filename=None):
         to be retrieved
     index_filename: str
         The name of the file containing the index
+    max_tile_width: int
+        How wide can each tile be before we return no data. This
+        can be used to limit the amount of data returned.
 
     Returns
     -------
@@ -163,10 +166,15 @@ def tiles(filename, tile_ids, index_filename=None):
         tile_position = list(map(int, tile_id_parts[1:3]))
 
         tile_width = tsinfo['max_width'] / 2 ** int(tile_position[0])
-        start_pos = int(tile_position[1]) * tile_width
-        end_pos = start_pos + tile_width
 
-        tile_value = load_reads(samfile, start_pos=start_pos, end_pos=end_pos)
-        generated_tiles += [(tile_id, tile_value)]
+        if max_tile_width and tile_width >= max_tile_width:
+            # this tile is larger than the max allowed
+            return [(tile_id, {'error': f'Tile too large, no data returned. Max tile size: {max_tile_width}'})]
+        else:
+            start_pos = int(tile_position[1]) * tile_width
+            end_pos = start_pos + tile_width
+
+            tile_value = load_reads(samfile, start_pos=start_pos, end_pos=end_pos)
+            generated_tiles += [(tile_id, tile_value)]
 
     return generated_tiles

--- a/test/bam_test.py
+++ b/test/bam_test.py
@@ -51,4 +51,15 @@ class MyTestCase(unittest.TestCase):
             ['x.9.0'],
             index_filename=index_filename
         )
+
         assert(len(tile)) > 0
+        assert(len(tile[0][1]) > 10)
+
+        tile = ctb.tiles(
+            filename_mismatched,
+            ['x.9.0'],
+            index_filename=index_filename,
+            max_tile_width=10
+        )
+
+        assert('error' in tile[0][1])


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Added an option to limit the maximum bam tile width

Why is it necessary?

- Bam files are not aggregated so tiles can become exceptionally large. This option lets whoever is creating the tileset limit the maximum size that a tile can span.

Fixes #___

## Checklist

- [x] Unit tests added or updated
- [x] Updated CHANGELOG.md
