### PR TITLE
Pick up the header if it's in the column names

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.13.1
+
+- Fix returned header values
+
 v0.13.0
 
 - Ran black on the entire code base

--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -580,7 +580,7 @@ def _bedfile(
     import sqlite3
 
     sqlite3.register_adapter(np.int64, lambda val: int(val))
-    print("output_file:", output_file)
+    print("output_file:", output_file, "header:", header)
     conn = sqlite3.connect(output_file)
 
     # store some meta data

--- a/clodius/tiles/beddb.py
+++ b/clodius/tiles/beddb.py
@@ -6,10 +6,6 @@ def tileset_info(db_file):
     cursor = conn.cursor()
 
     row = cursor.execute("SELECT * from tileset_info").fetchone()
-    if row is not None and len(row) == 9:
-        header = row[8]
-    else:
-        header = ""
 
     colnames = next(zip(*cursor.description))
 
@@ -17,6 +13,11 @@ def tileset_info(db_file):
         version = 1
     else:
         version = int(row[colnames.index("version")])
+
+    if "header" not in colnames:
+        header = ""
+    else:
+        header = row[colnames.index("header")]
 
     ts_info = {
         "zoom_step": row[0],

--- a/test/bedfile_test.py
+++ b/test/bedfile_test.py
@@ -145,6 +145,7 @@ def test_random_importance():
 
     tsinfo = ctb.tileset_info(f.name)
     assert "version" in tsinfo
+    assert len(tsinfo["header"]) > 0
 
     # check to make sure that tiles in the higher zoom levels
     # are all present in lower zoom levels


### PR DESCRIPTION
## Description

What was changed in this pull request?

Check for the header column in the sqlite file before returning headers.

Why is it necessary?

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
