### PR TITLE
Add name from bed file line to beddb db

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+v0.14.0
+
+- Add "name" field to `beddb` format
+
 v0.13.1
 
 - Fix returned header values

--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -441,7 +441,7 @@ def _bedfile(
     chromsizes_filename,
     offset,
 ):
-    BEDDB_VERSION = 2
+    BEDDB_VERSION = 3
 
     if output_file is None:
         output_file = filepath + ".beddb"
@@ -501,6 +501,10 @@ def _bedfile(
 
             start, stop = stop, start
 
+        if len(line) > 3:
+            bedline_name = line[3]
+        else:
+            bedline_name = ""
         # convert chromosome coordinates to genome coordinates
         genome_start = chrom_info.cum_chrom_lengths[chrom] + start + offset
         genome_end = chrom_info.cum_chrom_lengths[chrom] + stop + offset
@@ -510,6 +514,7 @@ def _bedfile(
             "startPos": genome_start,
             "endPos": genome_end,
             "uid": slugid.nice(),
+            "name": bedline_name,
             "chrOffset": pos_offset,
             "fields": "\t".join(line),
             "importance": importance,
@@ -623,6 +628,7 @@ def _bedfile(
             endPos int,
             chrOffset int,
             uid text,
+            name text,
             fields text
         )
         """
@@ -707,7 +713,7 @@ def _bedfile(
                 value = uid_to_entry[interval[-1]]
 
                 # one extra question mark for the primary key
-                exec_statement = "INSERT INTO intervals VALUES (?,?,?,?,?,?,?,?)"
+                exec_statement = "INSERT INTO intervals VALUES (?,?,?,?,?,?,?,?,?)"
 
                 c.execute(
                     exec_statement,
@@ -720,6 +726,7 @@ def _bedfile(
                         value["endPos"],
                         value["chrOffset"],
                         value["uid"],
+                        value["name"],
                         value["fields"],
                     ),
                 )

--- a/clodius/tiles/beddb.py
+++ b/clodius/tiles/beddb.py
@@ -209,7 +209,6 @@ def list_items(db_file, start, end, max_entries=None):
     """
     ts_info = tileset_info(db_file)
     version = ts_info["version"]
-    print("version:", version)
 
     conn = sqlite3.connect(db_file)
 

--- a/clodius/tiles/beddb.py
+++ b/clodius/tiles/beddb.py
@@ -125,9 +125,23 @@ def get_1D_tiles(db_file, zoom, tile_x_pos, num_tiles=1):
         zoom, tile_start_pos, tile_end_pos
     )
 
-    if version > 1:
+    if version == 2:
         query = """
         SELECT startPos, endPos, chrOffset, importance, fields, uid
+        FROM intervals,position_index
+        WHERE
+            intervals.id=position_index.id AND
+            rStartZoomLevel <= {} AND
+            rEndZoomLevel >= 0 AND
+            rEndPos >= {} AND
+            rStartPos <= {}
+        """.format(
+            zoom, tile_start_pos, tile_end_pos
+        )
+
+    if version == 3:
+        query = """
+        SELECT startPos, endPos, chrOffset, importance, fields, uid, name
         FROM intervals,position_index
         WHERE
             intervals.id=position_index.id AND
@@ -160,17 +174,19 @@ def get_1D_tiles(db_file, zoom, tile_x_pos, num_tiles=1):
             tile_x_end = (i + 1) * tile_width
 
             if x_start < tile_x_end and x_end >= tile_x_start:
-                new_rows += [
-                    # add the position offset to the returned values
-                    {
-                        "xStart": r[0],
-                        "xEnd": r[1],
-                        "chrOffset": r[2],
-                        "importance": r[3],
-                        "uid": uid,
-                        "fields": r[4].split("\t"),
-                    }
-                ]
+                to_add = {
+                    "xStart": r[0],
+                    "xEnd": r[1],
+                    "chrOffset": r[2],
+                    "importance": r[3],
+                    "uid": uid,
+                    "fields": r[4].split("\t"),
+                }
+
+                if version == 3:
+                    to_add["name"] = r[6]
+
+                new_rows += [to_add]
     conn.close()
 
     return new_rows
@@ -191,6 +207,9 @@ def list_items(db_file, start, end, max_entries=None):
     max_entries: int
         The maximum number of results to return
     """
+    ts_info = tileset_info(db_file)
+    version = ts_info["version"]
+    print("version:", version)
 
     conn = sqlite3.connect(db_file)
 
@@ -211,6 +230,33 @@ def list_items(db_file, start, end, max_entries=None):
         zoom, start, end
     )
 
+    if version == 2:
+        query = """
+        SELECT startPos, endPos, chrOffset, importance, fields, uid
+        FROM intervals,position_index
+        WHERE
+            intervals.id=position_index.id AND
+            rStartZoomLevel <= {} AND
+            rEndZoomLevel >= 0 AND
+            rEndPos >= {} AND
+            rStartPos <= {}
+        """.format(
+            zoom, start, end
+        )
+
+    if version == 3:
+        query = """
+        SELECT startPos, endPos, chrOffset, importance, fields, uid, name
+        FROM intervals,position_index
+        WHERE
+            intervals.id=position_index.id AND
+            rStartZoomLevel <= {} AND
+            rEndZoomLevel >= 0 AND
+            rEndPos >= {} AND
+            rStartPos <= {}
+        """.format(
+            zoom, start, end
+        )
     if max_entries is not None:
         query += " LIMIT {}".format(max_entries)
 
@@ -224,17 +270,19 @@ def list_items(db_file, start, end, max_entries=None):
         except AttributeError:
             uid = r[5]
 
-        new_rows += [
-            # add the position offset to the returned values
-            {
-                "xStart": r[0],
-                "xEnd": r[1],
-                "chrOffset": r[2],
-                "importance": r[3],
-                "uid": uid,
-                "fields": r[4].split("\t"),
-            }
-        ]
+        to_add = {
+            "xStart": r[0],
+            "xEnd": r[1],
+            "chrOffset": r[2],
+            "importance": r[3],
+            "uid": uid,
+            "fields": r[4].split("\t"),
+        }
+
+        if version == 3:
+            to_add["name"] = r[6]
+
+        new_rows += [to_add]
     conn.close()
 
     return new_rows

--- a/get_test_data.sh
+++ b/get_test_data.sh
@@ -12,4 +12,5 @@ wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.sorted.short.
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.different_index_filename.bai
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.sorted.short.bam.bai
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.mismatched_bai.bam
+wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/geneAnnotationsExonUnions.1000.bed.v3.beddb
 wget -q -NP data/ https://s3.amazonaws.com/areynolds/public/masterlist_DHSs_733samples_WM20180608_all_mean_signal_colorsMax.bed.bb

--- a/test/tiles/beddb_test.py
+++ b/test/tiles/beddb_test.py
@@ -12,5 +12,14 @@ def test_get_tiles():
 def test_list_items():
     filename = op.join("data", "gene_annotations.short.db")
 
-    hgbe.list_items(filename, 0, 100000000, max_entries=100)
+    items = hgbe.list_items(filename, 0, 100000000, max_entries=100)
+    assert "name" not in items[0]
     # TODO: Do something with the return value
+
+
+def test_name_in_tile():
+    filename = op.join("data", "geneAnnotationsExonUnions.1000.bed.v3.beddb")
+
+    tiles = hgbe.tiles(filename, ["x.1.0", "x.1.1"])
+
+    assert "name" in tiles[0][1][0]


### PR DESCRIPTION
## Description

What was changed in this pull request?

This PR update the `beddb` format to include a field for the name in a bed file entry.

Why is it necessary?

This is useful for auto-complete in gene search. Right now we search the entire bedfile line in the `fields` field when presenting autocomplete suggestions. This is problematic because if somebody enters _prot_ , the returned suggestions will be completely irrelevant because many gene annotations lines contain the term _protein coding_.

With this change, the `/api/v1/suggest` endpoint can be changed in `higlass-server` to only check the `name` field.

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
