### PR TITLE
dummy change to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Dummy change to see if travis would fail , because of https://github.com/pysam-developers/pysam/issues/860#issuecomment-576194976
+
 # Clodius
 
 [![Build Status](https://travis-ci.org/higlass/clodius.svg?branch=develop)](https://travis-ci.org/higlass/clodius)


### PR DESCRIPTION
## Description

investigating https://github.com/pysam-developers/pysam/issues/860 crashing `higlass-manage` tests

clodius does not depend on cython, so pysam build seem to fail (at least for higlass-manage) because pysam-devs didn't package pre-built `.c` files in the latest release https://github.com/pysam-developers/pysam/issues/860#issuecomment-576194976

What was changed in this pull request?

readme

Why is it necessary?
 to be discraded


Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
