### PR TITLE
Natural chromosome ordering in bam files

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+**Next**
+
+- Natural ordering of bam file chromosomes
+
 v0.14.0
 
 - Add "name" field to `beddb` format


### PR DESCRIPTION
# Description

What was changed in this pull request?

If no chromorder is given, this PR makes sure that that data loaded by BAM files is returned in its "natural" order (e.g. "chr1", "chr2",..., "chr10", "chr11",... "chrX", "chrY", "chrM".

Why is it necessary?

So that the behavior is consistent with bigWig and bigBed files.

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
