### PR TITLE
More accurate generation of tiles that span across chromosomes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- More accurate generation of multivec tiles that span across chromosomes
+
 v0.14.2
 
 - Make sure that chromsizes are serialized as ints

--- a/clodius/multivec.py
+++ b/clodius/multivec.py
@@ -59,7 +59,7 @@ def bedfile_to_multivec(
         chrom, start, end, vector = bedline_to_chrom_start_end_vector(lines, row_infos)
         # if vector[0] > 0 or vector[1] > 0:
         if len(vector) < len(lines) * num_rows:
-            logger.warn("Lines contain fewer columns than expected: %s", lines)
+            logger.warning("Lines contain fewer columns than expected: %s", lines)
             vector += [np.nan] * (len(lines) * num_rows - len(vector))
 
         if start % base_resolution != 0:

--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -162,12 +162,11 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
 
             chrom = chromsizes[cid][0]
 
-            offset = current_binned_data_position - current_data_position
             current_data_position += end - start
 
             count += 1
 
-            start_pos = math.floor((start + offset) / binsize)
+            start_pos = math.floor(start / binsize)
             end_pos = math.ceil(end / binsize)
 
             if start_pos >= end_pos:
@@ -196,6 +195,11 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
             current_binned_data_position += binsize * (end_pos - start_pos)
 
             # print("x:", x.shape)
+
+            # If the offset is larger than the binsize, drop the last bin
+            offset = current_binned_data_position - current_data_position
+            if offset > binsize:
+                x = x[:-1]
 
             # drop the very last bin if it is smaller than the binsize
             """

--- a/test/multivec_test.py
+++ b/test/multivec_test.py
@@ -192,3 +192,33 @@ def test_retain_lines():
         assert f["resolutions"]["1000"]["values"]["chr1"][10][0] == 0.0
         assert f["resolutions"]["1000"]["values"]["chr1"][10][1] == 1.0
         assert f["resolutions"]["1000"]["values"]["chr1"][10][2] == 0.0
+
+
+
+def test_chr_boundaries_states():
+
+    data_file = op.join(testdir, "sample_data", "chrm_boundaries_test.multires.mv5")
+    f = h5py.File(data_file, "r")
+
+    chromsizes = list(zip(f["chroms"]["name"], f["chroms"]["length"]))
+
+    # Tile that contains the boundary of chr1 and chr2 at highest resultion
+    tile1 = ctv.get_tile(f,chromsizes,200, 248934400, 248985600, [256, 4])
+
+    assert (tile1[110][0] == 1.0 and tile1[110][1] == 0.0)
+    assert (tile1[111][0] == 0.0 and tile1[111][1] == 1.0)
+
+    # Tile that contains the boundary of chr2 and chr3 at highest resultion
+    tile2 = ctv.get_tile(f,chromsizes,200, 491110400, 491161600, [256, 4])
+
+    assert (tile2[197][0] == 0.0 and tile2[197][1] == 1.0)
+    assert (tile2[198][0] == 1.0 and tile2[198][1] == 0.0)
+
+     # Tile that contains the boundary of chr5 and chr6 at highest resultion
+    tile3 = ctv.get_tile(f,chromsizes,200, 1061171200, 1061222400, [256, 4])
+
+    assert (tile3[135][0] == 1.0 and tile3[135][1] == 0.0)
+    assert (tile3[136][0] == 0.0 and tile3[136][1] == 1.0)
+
+
+

--- a/test/multivec_test.py
+++ b/test/multivec_test.py
@@ -194,7 +194,6 @@ def test_retain_lines():
         assert f["resolutions"]["1000"]["values"]["chr1"][10][2] == 0.0
 
 
-
 def test_chr_boundaries_states():
 
     data_file = op.join(testdir, "sample_data", "chrm_boundaries_test.multires.mv5")
@@ -203,22 +202,19 @@ def test_chr_boundaries_states():
     chromsizes = list(zip(f["chroms"]["name"], f["chroms"]["length"]))
 
     # Tile that contains the boundary of chr1 and chr2 at highest resultion
-    tile1 = ctv.get_tile(f,chromsizes,200, 248934400, 248985600, [256, 4])
+    tile1 = ctv.get_tile(f, chromsizes, 200, 248934400, 248985600, [256, 4])
 
     assert (tile1[110][0] == 1.0 and tile1[110][1] == 0.0)
     assert (tile1[111][0] == 0.0 and tile1[111][1] == 1.0)
 
     # Tile that contains the boundary of chr2 and chr3 at highest resultion
-    tile2 = ctv.get_tile(f,chromsizes,200, 491110400, 491161600, [256, 4])
+    tile2 = ctv.get_tile(f, chromsizes, 200, 491110400, 491161600, [256, 4])
 
     assert (tile2[197][0] == 0.0 and tile2[197][1] == 1.0)
     assert (tile2[198][0] == 1.0 and tile2[198][1] == 0.0)
 
-     # Tile that contains the boundary of chr5 and chr6 at highest resultion
-    tile3 = ctv.get_tile(f,chromsizes,200, 1061171200, 1061222400, [256, 4])
+    # Tile that contains the boundary of chr5 and chr6 at highest resultion
+    tile3 = ctv.get_tile(f, chromsizes, 200, 1061171200, 1061222400, [256, 4])
 
     assert (tile3[135][0] == 1.0 and tile3[135][1] == 0.0)
     assert (tile3[136][0] == 0.0 and tile3[136][1] == 1.0)
-
-
-


### PR DESCRIPTION
## Description

What was changed in this pull request?

This PR address a pixel shift issue that can be observed here: 
http://54.88.112.8:8170/l/?d=feRVfVIHS8iFojiyh1j9KQ
In the example above the entire Chr 2 has state 2 and Chr 3 has state 1. However, the tile between chr3:40 and chr3:240 has state 2. It should have state 1.

The PR modifies the tile generation as follows:
Current behavior:
<img width="929" alt="Screen Shot 2020-03-13 at 11 50 05 AM" src="https://user-images.githubusercontent.com/53857412/76637390-09be1600-6521-11ea-827b-c2e0037dbf65.png">

Proposed behavior:
<img width="929" alt="Screen Shot 2020-03-13 at 11 52 42 AM" src="https://user-images.githubusercontent.com/53857412/76637486-383bf100-6521-11ea-9390-3e475ca72d50.png">


Why is it necessary?

Improves accuracy of tile generation across chromosomes

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
