### PR TITLE
Improve 1d bedpedb tiles getter. Harmonize bedpedb function names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ v0.15.0
 - Show default values for `clodius aggregate bedpe -h`
 - Add short options to `clodius aggregate bedpe`
 - Make `clodius aggregate bedpe --chromosome` actually do something
+- For bedpedb 1D tiles, retrieve entries where either regions at least partially overlaps with a tile
+- Harmonize bedpedb tile getter names
 
 v0.14.3
 

--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -201,7 +201,7 @@ def _bedpe(
     BED2DDB_VERSION = 1
 
     if verbose > 0:
-        print(f'BEDPEDB Version {BED2DDB_VERSION}')
+        print(f"BEDPEDB Version {BED2DDB_VERSION}")
 
     if filepath == "-":
         f = sys.stdin
@@ -302,7 +302,7 @@ def _bedpe(
         ]
 
     if verbose > 0:
-        print(f'Found {len(entries)} entries')
+        print(f"Found {len(entries)} entries")
 
     # We need chromosome information as well as the assembly size to properly
     # tile this data
@@ -375,7 +375,7 @@ def _bedpe(
 
     def batch_insert(conn, c, interval_inserts, position_index_inserts):
         if verbose > 0:
-            print(f'Insert batch ({counter})')
+            print(f"Insert batch ({counter})")
 
         with transaction(conn):
             c.executemany(
@@ -1640,7 +1640,7 @@ def bedfile(
     default=500,
     show_default=True,
 )
-@click.option('-v', '--verbose', count=True, help="Increase log statements")
+@click.option("-v", "--verbose", count=True, help="Increase log statements")
 def bedpe(
     filepath,
     output_file,

--- a/clodius/cli/utils.py
+++ b/clodius/cli/utils.py
@@ -18,7 +18,7 @@ def transaction(conn):
         Nothing
     """
     # We must issue a "BEGIN" explicitly when running in auto-commit mode.
-    conn.execute('BEGIN')
+    conn.execute("BEGIN")
     try:
         # Yield control back to the caller.
         yield

--- a/clodius/tiles/bed2ddb.py
+++ b/clodius/tiles/bed2ddb.py
@@ -1,9 +1,12 @@
 import collections as col
 import sqlite3
+import time
+
+from .utils import tiles_wrapper_2d
 
 
-def get_2d_tileset_info(db_file):
-    conn = sqlite3.connect(db_file)
+def tileset_info(filepath):
+    conn = sqlite3.connect(filepath)
     c = conn.cursor()
 
     row = c.execute("SELECT * from tileset_info").fetchone()
@@ -24,54 +27,92 @@ def get_2d_tileset_info(db_file):
     return tileset_info
 
 
-def get_1D_tiles(db_file, zoom, tile_x_pos, numx):
+# Deprecated. Use `tileset_info()`
+def get_2d_tileset_info(filepath):
+    return tileset_info(filepath)
+
+
+def tiles(filepath, tile_ids, query_as_1d: bool = False):
+    if query_as_1d:
+        return tiles_1d(filepath, tile_ids)
+
+    return tiles_2d(filepath, tile_ids)
+
+
+def tiles_1d(filepath, tile_ids):
+    """
+    Generate 1D tiles from this dataset.
+    Parameters
+    ----------
+    filepath: str
+        The filename of the sqlite db file
+    tile_ids: [str...]
+        A list of tile ids of the form
+    Returns
+    -------
+    tiles: [(tile_id, tile_value),...]
+        A list of values indexed by the tile position
+    """
+    to_return = []
+
+    for tile_id in tile_ids:
+        _, z, x = tile_id.split(".")
+        to_return += [(tile_id, get_1d_tiles(filepath, int(z), int(x))[int(x)])]
+
+    return to_return
+
+
+def get_1d_tiles(filepath, zoom: int, tile_x_pos: int, num_tiles: int = 1):
     """
     Retrieve a contiguous set of tiles from a 2D db tile file.
 
     Parameters
     ----------
-    db_file: str
+    filepath: str
         The filename of the sqlite db file
     zoom: int
         The zoom level
     tile_x_pos: int
         The x position of the first tile
-    numx: int
-        The width of the block of tiles to retrieve
+    num_tiles: int
+        The number of tiles to retrieve
 
     Returns
     -------
     tiles: {pos: tile_value}
         A set of tiles, indexed by position
     """
-    tileset_info = get_2d_tileset_info(db_file)
+    ts_info = tileset_info(filepath)
 
-    conn = sqlite3.connect(db_file)
-
+    conn = sqlite3.connect(filepath)
     c = conn.cursor()
-    tile_width = tileset_info["max_width"] / 2 ** zoom
+
+    tile_width = ts_info["max_width"] / 2 ** zoom
 
     tile_x_start_pos = tile_width * tile_x_pos
-    tile_x_end_pos = tile_x_start_pos + (numx * tile_width)
+    tile_x_end_pos = tile_x_start_pos + (tile_width * num_tiles)
 
-    # print('tile_x_start:', tile_x_start_pos, tile_x_end_pos)
-
-    query = """
+    query = f"""
     SELECT fromX, toX, fromY, toY, chrOffset, importance, fields, uid
-    FROM intervals,position_index
+    FROM intervals, position_index
     WHERE
         intervals.id=position_index.id AND
-        zoomLevel <= {} AND
-        rToX >= {} AND
-        rFromX <= {}
-    """.format(
-        zoom, tile_x_start_pos, tile_x_end_pos
-    )
+        zoomLevel <= {zoom} AND
+        rToX >= {tile_x_start_pos} AND
+        rFromX <= {tile_x_end_pos}
+    UNION
+    SELECT fromX, toX, fromY, toY, chrOffset, importance, fields, uid
+    FROM intervals, position_index
+    WHERE
+        intervals.id=position_index.id AND
+        zoomLevel <= {zoom} AND
+        rToY >= {tile_x_start_pos} AND
+        rFromY <= {tile_x_end_pos}
+    """
 
     rows = c.execute(query).fetchall()
 
     new_rows = col.defaultdict(list)
-    # print("len(rows)", len(rows))
 
     for r in rows:
         try:
@@ -84,7 +125,7 @@ def get_1D_tiles(db_file, zoom, tile_x_pos, numx):
         y_start = r[2]
         y_end = r[3]
 
-        for i in range(tile_x_pos, tile_x_pos + numx):
+        for i in range(tile_x_pos, tile_x_pos + num_tiles):
             tile_x_start = i * tile_width
             tile_x_end = (i + 1) * tile_width
 
@@ -107,7 +148,17 @@ def get_1D_tiles(db_file, zoom, tile_x_pos, numx):
     return new_rows
 
 
-def get_2D_tiles(db_file, zoom, tile_x_pos, tile_y_pos, numx=1, numy=1):
+def get_1D_tiles(*args):
+    return get_1d_tiles(*args)
+
+
+def tiles_2d(filepath, tile_ids):
+    return tiles_wrapper_2d(
+        tile_ids, lambda z, x, y: get_2d_tiles(filepath, z, x, y)[(x, y)]
+    )
+
+
+def get_2d_tiles(db_file, zoom, tile_x_pos, tile_y_pos, numx=1, numy=1):
     """
     Retrieve a contiguous set of tiles from a 2D db tile file.
 
@@ -203,3 +254,7 @@ def get_2D_tiles(db_file, zoom, tile_x_pos, tile_y_pos, numx=1, numy=1):
     conn.close()
 
     return new_rows
+
+
+def get_2D_tiles(*args):
+    return get_2d_tiles(*args)

--- a/clodius/tiles/bed2ddb.py
+++ b/clodius/tiles/bed2ddb.py
@@ -1,6 +1,5 @@
 import collections as col
 import sqlite3
-import time
 
 from .utils import tiles_wrapper_2d
 

--- a/test/multivec_test.py
+++ b/test/multivec_test.py
@@ -204,17 +204,17 @@ def test_chr_boundaries_states():
     # Tile that contains the boundary of chr1 and chr2 at highest resultion
     tile1 = ctv.get_tile(f, chromsizes, 200, 248934400, 248985600, [256, 4])
 
-    assert (tile1[110][0] == 1.0 and tile1[110][1] == 0.0)
-    assert (tile1[111][0] == 0.0 and tile1[111][1] == 1.0)
+    assert tile1[110][0] == 1.0 and tile1[110][1] == 0.0
+    assert tile1[111][0] == 0.0 and tile1[111][1] == 1.0
 
     # Tile that contains the boundary of chr2 and chr3 at highest resultion
     tile2 = ctv.get_tile(f, chromsizes, 200, 491110400, 491161600, [256, 4])
 
-    assert (tile2[197][0] == 0.0 and tile2[197][1] == 1.0)
-    assert (tile2[198][0] == 1.0 and tile2[198][1] == 0.0)
+    assert tile2[197][0] == 0.0 and tile2[197][1] == 1.0
+    assert tile2[198][0] == 1.0 and tile2[198][1] == 0.0
 
     # Tile that contains the boundary of chr5 and chr6 at highest resultion
     tile3 = ctv.get_tile(f, chromsizes, 200, 1061171200, 1061222400, [256, 4])
 
-    assert (tile3[135][0] == 1.0 and tile3[135][1] == 0.0)
-    assert (tile3[136][0] == 0.0 and tile3[136][1] == 1.0)
+    assert tile3[135][0] == 1.0 and tile3[135][1] == 0.0
+    assert tile3[136][0] == 0.0 and tile3[136][1] == 1.0


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Harmonize the function names:
- Lower case "1d" and "2d" methods.
- A single get_tileset_info() as the info is the same for 1D and 2D.

Why is it necessary?

To have the same function names as other tile getter

## Checklist

-   [ ] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
