### PR TITLE
Flekschas/automatic 1d 2d bedpedb tiles

### DIFF
--- a/clodius/tiles/bed2ddb.py
+++ b/clodius/tiles/bed2ddb.py
@@ -31,8 +31,13 @@ def get_2d_tileset_info(filepath):
     return tileset_info(filepath)
 
 
-def tiles(filepath, tile_ids, query_as_1d: bool = False):
-    if query_as_1d:
+def tiles(filepath, tile_ids):
+    if len(tile_ids) == 0:
+        return []
+
+    is_1d = len(tile_ids[0].split(".")) < 4
+
+    if is_1d:
         return tiles_1d(filepath, tile_ids)
 
     return tiles_2d(filepath, tile_ids)

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -10,6 +10,8 @@ import numpy as np
 import os.path as op
 import sys
 
+from clodius.tiles import bed2ddb
+
 sys.path.append("scripts")
 
 testdir = op.realpath(op.dirname(__file__))
@@ -231,6 +233,14 @@ def test_clodius_aggregate_bedpe():
     tiles = cdt.get_2d_tiles(output_file, 0, 0, 0, numx=1, numy=1)
 
     assert "\n" not in tiles[(0, 0)][0]["fields"][2]
+
+    tiles_2d = bed2ddb.tiles(output_file, ['x.0.0.0'])
+
+    assert len(tiles_2d[0][1][0]["fields"]) == 3
+
+    tiles_1d = bed2ddb.tiles(output_file, ['x.0.0'])
+
+    assert len(tiles_1d[0][1][0]["fields"]) == 3
 
 
 testdir = op.realpath(op.dirname(__file__))


### PR DESCRIPTION
## Description

> What was changed in this pull request?

Automatically determine whether the client wants 1D or 2D bedpe tiles

> Why is it necessary?

Previously this had to be specified upfront

## Checklist

-   [x] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
