### PR TITLE
Get multivec row_infos from info/row_infos, as a dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ output.tar
 profile.dat
 profile.png
 aws_keys.py
+.envrc
 
 #test related
 a.out

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+- Added support for multivec `row_infos` stored under `/info/row_infos` as an hdf5 utf-8 string dataset.
+
 v0.14.3
 
 - Small bug when retrieving tile 0.0 from bam files

--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -285,7 +285,7 @@ def tileset_info(filename):
     if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
         row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
         tileset_info["row_infos"] = [r.decode("utf8") for r in row_infos]
-    elif "row_infos" in f["info"].keys():
+    elif "row_infos" in f["info"]:
         row_infos_encoded = f["info"]["row_infos"][()]
         tileset_info["row_infos"] = json.loads(row_infos_encoded)
 

--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -1,5 +1,6 @@
 import math
 import base64
+import json
 
 import h5py
 import numpy as np
@@ -280,6 +281,9 @@ def tileset_info(filename):
     if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
         row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
         tileset_info["row_infos"] = [r.decode("utf8") for r in row_infos]
+    elif "row_infos" in f["info"].keys():
+        row_infos_encoded = f["info"]["row_infos"][()]
+        tileset_info["row_infos"] = json.loads(row_infos_encoded)
 
     f.close()
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

This implements a getter for `row_infos` according to the proposal in the multivec spec document, where `row_infos` is a string dataset under the /info group.

Why is it necessary?

This allows us to store row_infos that have sizes above the hdf5 .attrs limits.

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [ ] Run `black .`
