### PR TITLE
Informative error msg if input bedfile is not sorted.

### DIFF
--- a/clodius/multivec.py
+++ b/clodius/multivec.py
@@ -102,7 +102,13 @@ def bedfile_to_multivec(
             print("line:", line)
         """
 
-        assert curr_index == data_start_index
+        if curr_index != data_start_index:
+            message = """
+The expected position location does not match the observed location at entry {}:{}-{}
+This is probably because the bedfile is not sorted. Please sort and try again.
+            """.format(chrom, start, end)
+            raise ValueError(message)
+        # assert curr_index == data_start_index, message
         # print('vector', vector)
 
         # When the binsize is not equal to the base_resolution


### PR DESCRIPTION
## Description

What was changed in this pull request?
An informative error message is now raised if the bedfile provided to multivec.bedfile_to_multivec is not sorted.

Why is it necessary?
Before, conversion of a bedfile to multivec failed on an uninformative assert, leaving the user to ponder what went wrong.

This change has been tested on a minimal example with the following bed as input:
1   100 200 0
1   200 300 1
1   1000    1100    4
1   500 600 3

This now produces the following output
```
$ clodius convert bedfile-to-multivec test.bed --assembly grch37
chrom_col: 1
temporary dir: /tmp/tmp9jfvqxya
base_resolution: 1
Traceback (most recent call last):
  File "/data/cb/maxas/anaconda3/envs/higlass/bin/clodius", line 8, in <module>
    sys.exit(cli())
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/clodius/cli/convert.py", line 427, in bedfile_to_multivec
    method,
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/clodius/cli/convert.py", line 217, in _bedgraph_to_multivec
    num_rows,
  File "/data/cb/maxas/anaconda3/envs/higlass/lib/python3.6/site-packages/clodius/multivec.py", line 110, in bedfile_to_multivec
    raise ValueError(message)
ValueError:
The expected position location does not match the observed location at entry 1:500-600
This is probably because the bedfile is not sorted. Please sort and try again.
```