### PR TITLE
Consolidated tsinfo chromsizes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 v0.16.0
 
 - Return `chromsizes` as a single array in beddb `tileset_info`
+- [BREAKING] Remove the `chrom_names` and `chrom_sizes` fields in the beddb tileset info
 
 v0.15.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.16.0
+
+- Return `chromsizes` as a single array in beddb `tileset_info`
+
 v0.15.4
 
 - Remove type=bool from bedpe aggregate function to fix "Got secondary option for non-boolean flag" error

--- a/clodius/tiles/beddb.py
+++ b/clodius/tiles/beddb.py
@@ -33,6 +33,7 @@ def tileset_info(db_file):
         "chromsizes": list(
             zip(row[3].split("\t"), [int(cs) for cs in row[4].split("\t")])
         ),
+        "info_version": "2"
     }
     conn.close()
 

--- a/clodius/tiles/beddb.py
+++ b/clodius/tiles/beddb.py
@@ -23,8 +23,6 @@ def tileset_info(db_file):
         "zoom_step": row[0],
         "max_length": row[1],
         "assembly": row[2],
-        "chrom_names": row[3],
-        "chrom_sizes": row[4],
         "tile_size": row[5],
         "max_zoom": row[6],
         "max_width": row[7],
@@ -32,6 +30,9 @@ def tileset_info(db_file):
         "max_pos": [row[1]],
         "header": header,
         "version": version,
+        "chromsizes": list(
+            zip(row[3].split("\t"), [int(cs) for cs in row[4].split("\t")])
+        ),
     }
     conn.close()
 

--- a/clodius/tiles/mrmatrix.py
+++ b/clodius/tiles/mrmatrix.py
@@ -1,26 +1,28 @@
 import numpy as np
 
-def tileset_info(f, bounds=None):
-    if 'min-pos' in f.attrs:
-        min_pos = f.attrs['min-pos']
-    else:
-        min_pos = [0,0]
 
-    if 'max-pos' in f.attrs:
-        max_pos = f.attrs['max-pos']
+def tileset_info(f, bounds=None):
+    if "min-pos" in f.attrs:
+        min_pos = f.attrs["min-pos"]
     else:
-        max_pos = f['resolutions']['1']['values'].shape
+        min_pos = [0, 0]
+
+    if "max-pos" in f.attrs:
+        max_pos = f.attrs["max-pos"]
+    else:
+        max_pos = f["resolutions"]["1"]["values"].shape
 
     return {
-        'min_pos': min_pos,
-        'max_pos': max_pos,
-        'resolutions': [int(r) for r in f['resolutions']],
-        'mirror_tiles': 'false',
-        'bins_per_dimension': 256,
+        "min_pos": min_pos,
+        "max_pos": max_pos,
+        "resolutions": [int(r) for r in f["resolutions"]],
+        "mirror_tiles": "false",
+        "bins_per_dimension": 256,
     }
 
-def tiles(f, z,x,y):
-    '''
+
+def tiles(f, z, x, y):
+    """
     Return tiles for the given region.
 
     Parameters:
@@ -33,16 +35,15 @@ def tiles(f, z,x,y):
         The tile's x position
     y: int
         The tile's y position
-    '''
-    resolutions = sorted(map(int, f['resolutions'].keys()))[::-1]
+    """
+    resolutions = sorted(map(int, f["resolutions"].keys()))[::-1]
     tsinfo = tileset_info(f)
-    n_bins = tsinfo['bins_per_dimension']
+    n_bins = tsinfo["bins_per_dimension"]
 
     if z >= len(resolutions):
-        raise ValueError('Zoom level out of bounds:', z,
-            "resolutions:", resolutions)
+        raise ValueError("Zoom level out of bounds:", z, "resolutions:", resolutions)
 
-    tile_width = tsinfo['bins_per_dimension']
+    tile_width = tsinfo["bins_per_dimension"]
 
     # Where in the matrix the tile starts
     tile_x_start = x * tile_width
@@ -51,15 +52,15 @@ def tiles(f, z,x,y):
     tile_x_end = tile_x_start + n_bins
     tile_y_end = tile_y_start + n_bins
 
-    mat = f['resolutions'][str(resolutions[z])]['values']
-    data = mat[tile_y_start:tile_y_end,
-        tile_x_start:tile_x_end]
+    mat = f["resolutions"][str(resolutions[z])]["values"]
+    data = mat[tile_y_start:tile_y_end, tile_x_start:tile_x_end]
 
     x_pad = n_bins - data.shape[0]
     y_pad = n_bins - data.shape[1]
 
     if x_pad > 0 or y_pad > 0:
-        data = np.pad(data, ((0, x_pad), (0, y_pad)), 'constant',
-            constant_values = (np.nan, np.nan))
+        data = np.pad(
+            data, ((0, x_pad), (0, y_pad)), "constant", constant_values=(np.nan, np.nan)
+        )
 
     return data

--- a/test/mrmatrix_test.py
+++ b/test/mrmatrix_test.py
@@ -3,78 +3,72 @@ import unittest
 import numpy as np
 from numpy.testing import assert_array_equal
 
-from clodius.tiles.mrmatrix import tileset_info, tiles
+from clodius.tiles.mrmatrix import tiles, tileset_info
+
 
 class AttrDict(dict):
     pass
 
-class TilesetInfoTest(unittest.TestCase):
 
+class TilesetInfoTest(unittest.TestCase):
     def setUp(self):
-        tileset_stub = {
-            'resolutions': {
-                '1': {
-                    'values': np.array([[1,2],[3,4]])
-                }
-            }
-        }
+        tileset_stub = {"resolutions": {"1": {"values": np.array([[1, 2], [3, 4]])}}}
 
         self.tileset = AttrDict(tileset_stub)
         self.tileset.attrs = {}
 
         self.tileset_min = AttrDict(tileset_stub)
-        self.tileset_min.attrs = {'min-pos': (1, 1)}
+        self.tileset_min.attrs = {"min-pos": (1, 1)}
 
         self.tileset_max = AttrDict(tileset_stub)
-        self.tileset_max.attrs = {'max-pos': (9, 9)}
+        self.tileset_max.attrs = {"max-pos": (9, 9)}
 
         self.info = {
-            'bins_per_dimension': 256,
-            'max_pos': (2, 2),       # TODO: Nothing uses these...
-            'min_pos': [0, 0],       # ...
-            'mirror_tiles': 'false', # Can we remove them?
-            'resolutions': [1]
+            "bins_per_dimension": 256,
+            "max_pos": (2, 2),  # TODO: Nothing uses these...
+            "min_pos": [0, 0],  # ...
+            "mirror_tiles": "false",  # Can we remove them?
+            "resolutions": [1],
         }
 
     def test_default(self):
         self.assertEqual(tileset_info(self.tileset), self.info)
-        self.assertEqual(tileset_info(self.tileset, bounds='???'), self.info)
+        self.assertEqual(tileset_info(self.tileset, bounds="???"), self.info)
 
     def test_with_min(self):
-        self.info['min_pos'] = (1, 1)
+        self.info["min_pos"] = (1, 1)
         self.assertEqual(tileset_info(self.tileset_min), self.info)
-        self.assertEqual(tileset_info(self.tileset_min, bounds='???'), self.info)
+        self.assertEqual(tileset_info(self.tileset_min, bounds="???"), self.info)
 
     def test_with_max(self):
-        self.info['max_pos'] = (9, 9)
+        self.info["max_pos"] = (9, 9)
         self.assertEqual(tileset_info(self.tileset_max), self.info)
-        self.assertEqual(tileset_info(self.tileset_max, bounds='???'), self.info)
+        self.assertEqual(tileset_info(self.tileset_max, bounds="???"), self.info)
 
 
 class TilesTest(unittest.TestCase):
     def test_zoom_out_of_bounds(self):
         def should_fail():
-            tileset_stub = AttrDict({
-                'resolutions': {
-                    '1': {
-                        'values': np.array([[1,2],[3,4]])
-                    }
-                }
-            })
+            tileset_stub = AttrDict(
+                {"resolutions": {"1": {"values": np.array([[1, 2], [3, 4]])}}}
+            )
             tileset_stub.attrs = {}
             tiles(tileset_stub, 2, 0, 0)
-        self.assertRaisesRegex(ValueError, r'Zoom level out of bounds', should_fail)
+
+        self.assertRaisesRegex(ValueError, r"Zoom level out of bounds", should_fail)
 
     def test_padding(self):
-        tileset = AttrDict({
-            'resolutions': {
-                '1': {
-                    'values': np.array([[1.0, 2], [3, 4]])
-                    # It's important that there is a float value:
-                    # If there isn't, np.nan will be converted to a large negative integer.
+        tileset = AttrDict(
+            {
+                "resolutions": {
+                    "1": {
+                        "values": np.array([[1.0, 2], [3, 4]])
+                        # It's important that there is a float value:
+                        # If there isn't, np.nan will be converted to a large negative integer.
+                    }
                 }
             }
-        })
+        )
         tileset.attrs = {}
         zoomed = tiles(tileset, 0, 0, 0)
         self.assertEqual(zoomed.shape, (256, 256))
@@ -82,13 +76,17 @@ class TilesTest(unittest.TestCase):
         assert_array_equal(zoomed[2:256, 0], [np.nan for x in range(254)])
 
     def test_bins(self):
-        tileset = AttrDict({
-            'resolutions': {
-                '1': {
-                    'values': np.array([[float(x) for x in range(500)] for y in range(500)])
+        tileset = AttrDict(
+            {
+                "resolutions": {
+                    "1": {
+                        "values": np.array(
+                            [[float(x) for x in range(500)] for y in range(500)]
+                        )
+                    }
                 }
             }
-        })
+        )
         tileset.attrs = {}
 
         zoomed_0 = tiles(tileset, 0, 0, 0)
@@ -98,28 +96,24 @@ class TilesTest(unittest.TestCase):
         zoomed_1 = tiles(tileset, 0, 1, 1)
         self.assertEqual(zoomed_1.shape, (256, 256))
         self.assertEqual(zoomed_1[0, 0], 256)
-        self.assertEqual(zoomed_1[1, 0], 256) # Constant dimension
-        self.assertEqual(zoomed_1[0, 1], 257) # Changing dimension
+        self.assertEqual(zoomed_1[1, 0], 256)  # Constant dimension
+        self.assertEqual(zoomed_1[0, 1], 257)  # Changing dimension
         self.assertEqual(zoomed_1[0, 256 - 13], 499)
-        assert_array_equal(zoomed_1[0:1, (256 - 12):(256 - 12 + 1)], [[np.nan]])
+        assert_array_equal(zoomed_1[0:1, (256 - 12) : (256 - 12 + 1)], [[np.nan]])
         # Plain assertEqual gave: nan != nan
 
     def test_zoom(self):
-        tileset = AttrDict({
-            'resolutions': {
-                # TODO: It's not actually enforced that zoom levels be sequential integers?
-                # TODO: Should we check that the sizes are reasonable during initialization?
-                '1': {
-                    'values': np.array([[1,2],[3,4]])
-                },
-                '5': {
-                    'values': np.array([[3,4],[5,6]])
-                },
-                '11': {
-                    'values': np.array([[5,6],[7,8]])
+        tileset = AttrDict(
+            {
+                "resolutions": {
+                    # TODO: It's not actually enforced that zoom levels be sequential integers?
+                    # TODO: Should we check that the sizes are reasonable during initialization?
+                    "1": {"values": np.array([[1.0, 2.0], [3.0, 4.0]])},
+                    "5": {"values": np.array([[3.0, 4.0], [5.0, 6.0]])},
+                    "11": {"values": np.array([[5.0, 6.0], [7.0, 8.0]])},
                 }
             }
-        })
+        )
         tileset.attrs = {}
 
         zoomed_0 = tiles(tileset, 0, 0, 0)

--- a/test/tiles/beddb_test.py
+++ b/test/tiles/beddb_test.py
@@ -1,5 +1,6 @@
-import clodius.tiles.beddb as hgbe
 import os.path as op
+
+import clodius.tiles.beddb as hgbe
 
 
 def test_get_tiles():
@@ -23,3 +24,12 @@ def test_name_in_tile():
     tiles = hgbe.tiles(filename, ["x.1.0", "x.1.1"])
 
     assert "name" in tiles[0][1][0]
+
+
+def test_tileset_info():
+    filename = op.join("data", "geneAnnotationsExonUnions.1000.bed.v3.beddb")
+
+    tsinfo = hgbe.tileset_info(filename)
+
+    print("tsinfo", tsinfo)
+    assert "chromsizes" in tsinfo

--- a/test/tiles/beddb_test.py
+++ b/test/tiles/beddb_test.py
@@ -31,5 +31,4 @@ def test_tileset_info():
 
     tsinfo = hgbe.tileset_info(filename)
 
-    print("tsinfo", tsinfo)
     assert "chromsizes" in tsinfo

--- a/test/tiles/npvector_test.py
+++ b/test/tiles/npvector_test.py
@@ -1,9 +1,10 @@
 import numpy as np
+
 import clodius.tiles.npvector as hgnv
 
 
 def test_npvector():
-    array = np.array(range(100))
+    array = np.array([float(f) for f in range(100)])
     # print('ts:', hgnv.tileset_info(array))
     assert "max_width" in hgnv.tileset_info(array)
 


### PR DESCRIPTION
## Description

- Return chromsizes as an array instead of as two separate tab-separated fields (`chrom_sizes` and `chrom_names`). This harmonizes the return type with the return type for cooler tileset_info.

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
