### PR TITLE
Don't hard pin requirement versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,10 @@
 numpy
 negspy
 pysam
-dask==2021.12.0
+dask
 requests
 h5py>=3.0.0
-pandas==1.0.4
+pandas>=1.0
 slugid
 sortedcontainers
 nose
@@ -13,4 +13,4 @@ pybbi>=0.2.0
 Click>=7
 pydantic
 pyfaidx
-tqdm==4.62.3
+tqdm


### PR DESCRIPTION
The recently introduced exact version pins  started breaking installations on Python 3.9+