### PR TITLE
Check if row infos need decoding and if they're json-formatted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+v0.19.0
+
+- Fix decoding error in multivec tileset info
+- Allow JSON in multivec tileset info
+
 v0.18.1
 
 - Don't pin versions in requirements.txt

--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -260,7 +260,20 @@ def tileset_info(filename):
 
     if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
         row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
-        tileset_info["row_infos"] = [r.decode("utf8") for r in row_infos]
+
+        if type(row_infos[0]) == str:
+            try:
+                tileset_info["row_infos"] = [json.loads(r) for r in row_infos]
+            except json.JSONDecodeError:
+                tileset_info["row_infos"] = [r for r in row_infos]
+        else:
+            try:
+                tileset_info["row_infos"] = [
+                    json.loads(r.decode("utf8")) for r in row_infos
+                ]
+            except json.JSONDecodeError:
+                tileset_info["row_infos"] = [r.decode("utf8") for r in row_infos]
+
     elif "row_infos" in f["info"]:
         row_infos_encoded = f["info"]["row_infos"][()]
         tileset_info["row_infos"] = json.loads(row_infos_encoded)

--- a/get_test_data.sh
+++ b/get_test_data.sh
@@ -14,3 +14,4 @@ wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.sorted.short.
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.mismatched_bai.bam
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/geneAnnotationsExonUnions.1000.bed.v3.beddb
 wget -q -NP data/ https://s3.amazonaws.com/areynolds/public/masterlist_DHSs_733samples_WM20180608_all_mean_signal_colorsMax.bed.bb
+wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/clodius/tests/states_format_input_testfile.100.bed.multires.mv5

--- a/get_test_data.sh
+++ b/get_test_data.sh
@@ -14,4 +14,4 @@ wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.sorted.short.
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/SRR1770413.mismatched_bai.bam
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/geneAnnotationsExonUnions.1000.bed.v3.beddb
 wget -q -NP data/ https://s3.amazonaws.com/areynolds/public/masterlist_DHSs_733samples_WM20180608_all_mean_signal_colorsMax.bed.bb
-wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/clodius/tests/states_format_input_testfile.100.bed.multires.mv5
+wget -q -NP data/ https://resgen-public.s3.amazonaws.com/clodius/test-data/states_format_input_testfile.100.bed.multires.mv5

--- a/test/tiles/multivec_test.py
+++ b/test/tiles/multivec_test.py
@@ -40,12 +40,15 @@ def test_multivec():
             base64.b64encode(single_tile.ravel()).decode("utf-8") == tile_value["dense"]
         )
 
+
 def test_states():
-    filename = op.join("test/sample_data", "states_format_input_testfile.100.bed.multires.mv5")
+    filename = op.join(
+        "test/sample_data", "states_format_input_testfile.100.bed.multires.mv5"
+    )
 
     # make sure we can retrieve the tileset info
     tsinfo = hgmu.tileset_info(filename)
-    assert 10000000 in tsinfo['resolutions']
+    assert 10000000 in tsinfo["resolutions"]
 
-    tiles = hgmu.tiles(filename, ['x.0.0'])
-    assert 'shape' in tiles[0][1]
+    tiles = hgmu.tiles(filename, ["x.0.0"])
+    assert "shape" in tiles[0][1]

--- a/test/tiles/multivec_test.py
+++ b/test/tiles/multivec_test.py
@@ -39,3 +39,13 @@ def test_multivec():
         assert (
             base64.b64encode(single_tile.ravel()).decode("utf-8") == tile_value["dense"]
         )
+
+def test_states():
+    filename = op.join("test/sample_data", "states_format_input_testfile.100.bed.multires.mv5")
+
+    # make sure we can retrieve the tileset info
+    tsinfo = hgmu.tileset_info(filename)
+    assert 10000000 in tsinfo['resolutions']
+
+    tiles = hgmu.tiles(filename, ['x.0.0'])
+    assert 'shape' in tiles[0][1]

--- a/test/tiles/multivec_test.py
+++ b/test/tiles/multivec_test.py
@@ -43,7 +43,7 @@ def test_multivec():
 
 def test_states():
     filename = op.join(
-        "test/sample_data", "states_format_input_testfile.100.bed.multires.mv5"
+        "data", "states_format_input_testfile.100.bed.multires.mv5"
     )
 
     # make sure we can retrieve the tileset info


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Check if row infos need decoding
- Check if row infos are JSON and return as JSON

Why is it necessary?

- To prevent decoding error:

```
~/projects/clodius/clodius/tiles/multivec.py in <listcomp>(.0)
    262         row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
    263 
--> 264         tileset_info["row_infos"] = [r.decode("utf8") for r in row_infos]
    265     elif "row_infos" in f["info"]:
    266         row_infos_encoded = f["info"]["row_infos"][()]

AttributeError: 'str' object has no attribute 'decode'
```

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
