### PR TITLE
chore: favor 'items()' over 'iteritems()'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+In progress
+
+- Replace instances of `.iteritems()` with `.items()`
+
 v0.19.0
 
 - Fix decoding error in multivec tileset info

--- a/clodius/tiles/bam.py
+++ b/clodius/tiles/bam.py
@@ -84,7 +84,7 @@ def load_reads(
     if chromsizes is not None:
         chromsizes_list = []
 
-        for chrom, size in chromsizes.iteritems():
+        for chrom, size in chromsizes.items():
             chromsizes_list += [[chrom, int(size)]]
     else:
         references = np.array(samfile.references)
@@ -274,7 +274,7 @@ def alignment_tileset_info(samfile, chromsizes):
     if chromsizes is not None:
         chromsizes_list = []
 
-        for chrom, size in chromsizes.iteritems():
+        for chrom, size in chromsizes.items():
             chromsizes_list += [[chrom, int(size)]]
 
         total_length = sum([c[1] for c in chromsizes_list])

--- a/clodius/tiles/bigwig.py
+++ b/clodius/tiles/bigwig.py
@@ -65,7 +65,7 @@ def tileset_info(bwpath, chromsizes=None):
         chromsizes = get_chromsizes(bwpath)
         chromsizes_list = []
 
-        for chrom, size in chromsizes.iteritems():
+        for chrom, size in chromsizes.items():
             chromsizes_list += [[chrom, int(size)]]
     else:
         chromsizes_list = chromsizes
@@ -263,7 +263,7 @@ def chromsizes(filename):
     try:
         chrom_series = get_chromsizes(filename)
         data = []
-        for chrom, size in chrom_series.iteritems():
+        for chrom, size in chrom_series.items():
             data.append([chrom, size])
         return data
     except Exception as ex:

--- a/clodius/tiles/cooler.py
+++ b/clodius/tiles/cooler.py
@@ -501,7 +501,7 @@ def make_mats(filepath):
         info["min_pos"] = [1, 1]
 
         c = cooler.Cooler(f["resolutions"][resolution])
-        info["chromsizes"] = [[x[0], int(x[1])] for x in c.chromsizes.iteritems()]
+        info["chromsizes"] = [[x[0], int(x[1])] for x in c.chromsizes.items()]
         if "storage-mode" in c.info and c.info["storage-mode"] == "square":
             info["mirror_tiles"] = "false"
     else:
@@ -509,7 +509,7 @@ def make_mats(filepath):
 
         c = cooler.Cooler(f["0"])
 
-        info["chromsizes"] = [[x[0], int(x[1])] for x in c.chromsizes.iteritems()]
+        info["chromsizes"] = [[x[0], int(x[1])] for x in c.chromsizes.items()]
         info["min_pos"] = [int(m) for m in info["min_pos"]]
         info["max_pos"] = [int(m) for m in info["max_pos"]]
         info["max_zoom"] = int(info["max_zoom"])

--- a/clodius/tiles/fasta.py
+++ b/clodius/tiles/fasta.py
@@ -41,7 +41,7 @@ def tileset_info(fapath, chromsizes=None):
         chromsizes = get_chromsizes(fapath)
         chromsizes_list = []
 
-        for chrom, size in chromsizes.iteritems():
+        for chrom, size in chromsizes.items():
             chromsizes_list += [[chrom, int(size)]]
     else:
         chromsizes_list = chromsizes
@@ -191,7 +191,7 @@ def chromsizes(filename):
     try:
         chrom_series = get_chromsizes(filename)
         data = []
-        for chrom, size in chrom_series.iteritems():
+        for chrom, size in chrom_series.items():
             data.append([chrom, size])
         return data
     except Exception as ex:


### PR DESCRIPTION
## Description

What was changed in this pull request?

Replaces instances of `dict.iteritems()` with `dict.items()`.

Why is it necessary?

Use of `iteritems()` raises a deprecation notice in Python 3.10 and above.

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
