### PR TITLE
fix: use builtin warnings instead of np.warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+In progress
+
+- Use builtin `warnings` module instead of relying on alias from `numpy`.
+
 v0.19.0
 
 - Fix decoding error in multivec tileset info

--- a/clodius/tiles/format.py
+++ b/clodius/tiles/format.py
@@ -1,4 +1,6 @@
 import base64
+import warnings
+
 import numpy as np
 
 
@@ -22,8 +24,8 @@ def format_dense_tile(data):
     tile_data = {}
 
     if len(data):
-        with np.warnings.catch_warnings():
-            np.warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", r"All-NaN (slice|axis) encountered")
 
             max_dense = float(np.nanmax(data))
             min_dense = float(np.nanmin(data))


### PR DESCRIPTION
## Description

What was changed in this pull request?

Replaces the use of `np.warnings` with Python's builtin `warnings` module. It seems like the formers was a alias for the latter in older versions of Python and is no longer, breaking clodius in `numpy` v1.24.

Why is it necessary?

Allows latest numpy to be compatible with clodius.

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
