### PR TITLE
fix: setup doesn't require numpy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+In progress
+
+- remove `numpy` from setup requires
+
 v0.19.0
 
 - Fix decoding error in multivec tileset info

--- a/setup.py
+++ b/setup.py
@@ -18,9 +18,6 @@ def get_requirements(path):
     content = read(path)
     return [req for req in content.split("\n") if req != "" and not req.startswith("#")]
 
-
-setup_requires = ["numpy"]
-
 install_requires = get_requirements("requirements.txt")
 
 setup(
@@ -31,7 +28,6 @@ setup(
     author_email="pkerpedjiev@gmail.com",
     url="",
     packages=["clodius", "clodius.cli", "clodius.tiles"],
-    setup_requires=setup_requires,
     install_requires=install_requires,
     scripts=["scripts/tsv_to_mrmatrix.py"],
     entry_points={"console_scripts": ["clodius = clodius.cli.aggregate:cli"]},


### PR DESCRIPTION
## Description

What was changed in this pull request?

Removes `numpy` from setup.py `setup_requires`. 

Why is it necessary?

Setup doesn't actually require numpy, and `pip install -e .` fails with numpy `v1.24.2`. We can avoid this all together by removing it. If we need a build dependency, it should be specified with `build-system` in a pyproject.toml.

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
