### PR TITLE
Use in-place sort

### DIFF
--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -369,7 +369,7 @@ def _bedpe(
 
     tile_counts = col.defaultdict(lambda: col.defaultdict(lambda: col.defaultdict(int)))
     # Sort from high to low importance
-    entries = sorted(entries, key=lambda x: -x["importance"])
+    entries.sort(key=lambda x: -x["importance"])
 
     interval_inserts = []
     position_index_inserts = []


### PR DESCRIPTION
## Description

What was changed in this pull request?
This change replace `sorted` with in-place `sort` for `entries`.

Why is it necessary?
Since the intention was to sort the `entries` list and the unsorted list is never used, this change improves both the runtime performance and memory footprint. 


## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [x] Run `black .`
