### PR TITLE
Fixed type mismatch (#154)

### DIFF
--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -901,8 +901,8 @@ def _bedgraph(
     def add_values_to_data_buffers(buffers_to_add, nan_buffers_to_add):
         curr_zoom = 0
 
-        data_buffers[0] += buffers_to_add
-        nan_data_buffers[0] += nan_buffers_to_add
+        data_buffers[0] += [bta.astype(np.float64) for bta in buffers_to_add]
+        nan_data_buffers[0] += [nbta.astype(np.float64) for nbta in nan_buffers_to_add]
 
         curr_time = time.time() - t1
         percent_progress = (positions[curr_zoom] + 1) / float(assembly_size)

--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -901,8 +901,8 @@ def _bedgraph(
     def add_values_to_data_buffers(buffers_to_add, nan_buffers_to_add):
         curr_zoom = 0
 
-        data_buffers[0] += buffers_to_add
-        nan_data_buffers[0] += nan_buffers_to_add
+        data_buffers[0] += buffers_to_add.astype(np.float64)
+        nan_data_buffers[0] += nan_buffers_to_add.astype(np.float64)
 
         curr_time = time.time() - t1
         percent_progress = (positions[curr_zoom] + 1) / float(assembly_size)

--- a/clodius/cli/aggregate.py
+++ b/clodius/cli/aggregate.py
@@ -901,8 +901,8 @@ def _bedgraph(
     def add_values_to_data_buffers(buffers_to_add, nan_buffers_to_add):
         curr_zoom = 0
 
-        data_buffers[0] += [bta.astype(np.float64) for bta in buffers_to_add]
-        nan_data_buffers[0] += [nbta.astype(np.float64) for nbta in nan_buffers_to_add]
+        data_buffers[0] += [np.float64(bta) for bta in buffers_to_add]
+        nan_data_buffers[0] += [np.float64(nbta) for nbta in nan_buffers_to_add]
 
         curr_time = time.time() - t1
         percent_progress = (positions[curr_zoom] + 1) / float(assembly_size)


### PR DESCRIPTION
## Description

What was changed in this pull request?
The initial values inserted into `nan_data_buffers` were of type `numpy.int64`, and now they are cast to `numpy.float64`.

Why is it necessary?

Fixes #154 

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
