### PR TITLE
Fixed checking of types

### DIFF
--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -261,7 +261,7 @@ def tileset_info(filename):
     if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
         row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
 
-        if type(row_infos[0]) == str:
+        if type(row_infos[0]) is str:
             try:
                 tileset_info["row_infos"] = [json.loads(r) for r in row_infos]
             except json.JSONDecodeError:


### PR DESCRIPTION
## Description

What was changed in this pull request?
Checking types should be done with `isinstance` or `is` and not`==`. This PR fixes that.

Why is it necessary?
It is the canonical way and also the flake8 warns about it.

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
