### PR TITLE
fix: Convert chromsizes to int64 in cooler tiles to prevent overflow …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.9', '3.10']
 
     steps:
     - uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.20.2
+
+- Convert cooler chromsizes to int64 to prevent overflow error with recent versions of h5py and numpy
+
 v0.20.1
 
 - Remove use of deprecated `max_chunk` argument from cooler tile fetcher.

--- a/clodius/tiles/cooler.py
+++ b/clodius/tiles/cooler.py
@@ -57,7 +57,7 @@ def get_chromosome_names_cumul_lengths(c):
     (names, sizes, lengths) -> (list(string), dict, np.array(int))
     """
     chrom_names = c.chromnames
-    chrom_sizes = dict(c.chromsizes)
+    chrom_sizes = dict(c.chromsizes.astype(np.int64))
     chrom_cum_lengths = np.r_[0, np.cumsum(c.chromsizes.values)]
     return chrom_names, chrom_sizes, chrom_cum_lengths
 

--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -261,7 +261,7 @@ def tileset_info(filename):
     if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
         row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
 
-        if type(row_infos[0]) == str:
+        if isinstance(row_infos[0], str):
             try:
                 tileset_info["row_infos"] = [json.loads(r) for r in row_infos]
             except json.JSONDecodeError:


### PR DESCRIPTION
…error

## Description

Convert cooler chromsizes to int64 to prevent overflow error with h5py == 3.13.0 and numpy == 2.2.3

Why is it necessary?

Fixes #\_\_\_

## Checklist

-   [ ] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [ ] Run `black .`
