### PR TITLE
feat: Return chromsizes tileset info

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.20.3
+
+- Add chromsizes tileset_info function
+
 v0.20.2
 
 - Convert cooler chromsizes to int64 to prevent overflow error with recent versions of h5py and numpy

--- a/clodius/models/tileset_info.py
+++ b/clodius/models/tileset_info.py
@@ -1,0 +1,10 @@
+from typing import List, Optional
+
+from pydantic import BaseModel
+
+
+class TilesetInfo(BaseModel):
+	max_width: int
+	min_pos: List[int]
+	max_pos: List[int]
+	chromsizes: Optional[List]

--- a/clodius/models/tileset_info.py
+++ b/clodius/models/tileset_info.py
@@ -4,7 +4,7 @@ from pydantic import BaseModel
 
 
 class TilesetInfo(BaseModel):
-	max_width: int
-	min_pos: List[int]
-	max_pos: List[int]
-	chromsizes: Optional[List]
+    max_width: int
+    min_pos: List[int]
+    max_pos: List[int]
+    chromsizes: Optional[List]

--- a/clodius/tiles/chromsizes.py
+++ b/clodius/tiles/chromsizes.py
@@ -1,35 +1,51 @@
 import csv
 import logging
+from smart_open import open
 
 logger = logging.getLogger(__name__)
 
 
-def get_tsv_chromsizes(filename):
+def tileset_info(filename):
+    chromsizes = get_tsv_chromsizes(filename)
+
+    max_width = sum([int(c[1]) for c in chromsizes])
+    return {
+        "max_width": max_width,
+        "chromsizes": [[c[0], int(c[1])] for c in chromsizes],
+        "min_pos": [0],
+        "max_pos": [max_width],
+    }
+
+
+def get_tsv_chromsizes(file):
     """
     Get a list of chromosome sizes from this [presumably] tsv
-    chromsizes file file.
+    chromsizes file.
 
     Parameters:
     -----------
-    filename: string
-        The filename of the tsv file
+    file: string or file-like object
+        A file-like object
 
     Returns
     -------
     chromsizes: [(name:string, size:int), ...]
         An ordered list of chromosome names and sizes
     """
-    try:
-        with open(filename, "r") as f:
-            reader = csv.reader(f, delimiter="\t")
+    if isinstance(file, str):
+        file = open(file, "rb")
 
-            data = []
-            for row in reader:
-                data.append(row)
+    try:
+        file.seek(0)
+        binary_data = file.read()
+        text_data = binary_data.decode("utf-8")
+
+        lines = text_data.split("\n")
+        data = [l.strip().split("\t") for l in lines if l.strip()]
         return data
     except Exception as ex:
         logger.error(ex)
 
-        err_msg = "WHAT?! Could not load file %s. 😤 (%s)" % (filename, ex)
+        err_msg = "WHAT?! Could not load file %s." % (ex)
 
         raise Exception(err_msg)

--- a/clodius/tiles/chromsizes.py
+++ b/clodius/tiles/chromsizes.py
@@ -4,7 +4,18 @@ from smart_open import open
 logger = logging.getLogger(__name__)
 
 
-def tileset_info(filename):
+def tileset_info(filename: str) -> dict:
+    """Return a standard higlass tileset info object that contains
+    chromsizes as an element.
+
+    The chromsizes in the returned object will be a list of [name, size]
+    tuples.
+
+    [
+        ['chr1', 1000],
+        ['chr2', 2000]
+    ]
+    """
     chromsizes = get_tsv_chromsizes(filename)
 
     max_width = sum([int(c[1]) for c in chromsizes])

--- a/clodius/tiles/chromsizes.py
+++ b/clodius/tiles/chromsizes.py
@@ -1,4 +1,3 @@
-import csv
 import logging
 from smart_open import open
 
@@ -41,7 +40,7 @@ def get_tsv_chromsizes(file):
         text_data = binary_data.decode("utf-8")
 
         lines = text_data.split("\n")
-        data = [l.strip().split("\t") for l in lines if l.strip()]
+        data = [line.strip().split("\t") for line in lines if line.strip()]
         return data
     except Exception as ex:
         logger.error(ex)

--- a/get_test_data.sh
+++ b/get_test_data.sh
@@ -1,3 +1,4 @@
+wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/chromSizes.tsv
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/all.KL.bed.multires.mv5
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/Dixon2012-J1-NcoI-R1-filtered.100kb.multires.cool
 wget -q -NP data/ https://s3.amazonaws.com/pkerp/public/hic-resolutions.cool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "slugid",
     "sortedcontainers",
     "tqdm",
+    "smart_open"
 ]
 license = { text = "MIT" }
 readme = "README.md"

--- a/test/tiles/chromsizes_test.py
+++ b/test/tiles/chromsizes_test.py
@@ -7,8 +7,16 @@ from clodius.models.tileset_info import TilesetInfo
 def test_get_tileset_info():
     filename = op.join("data", "chromSizes.tsv")
 
+    # Test loading tileset info using a filename
     tsinfo = TilesetInfo(**ctcs.tileset_info(filename))
 
     assert tsinfo.max_width > 100
     assert len(tsinfo.chromsizes) > 2
     # TODO: Do something with the return value
+
+    with open(filename, "r") as f:
+        # Test loading using a file-like object
+        tsinfo = TilesetInfo(**ctcs.tileset_info(f))
+
+        assert tsinfo.max_width > 100
+        assert len(tsinfo.chromsizes) > 2

--- a/test/tiles/chromsizes_test.py
+++ b/test/tiles/chromsizes_test.py
@@ -1,0 +1,14 @@
+import os.path as op
+
+import clodius.tiles.chromsizes as ctcs
+from clodius.models.tileset_info import TilesetInfo
+
+
+def test_get_tileset_info():
+    filename = op.join("data", "chromSizes.tsv")
+
+    tsinfo = TilesetInfo(**ctcs.tileset_info(filename))
+
+    assert tsinfo.max_width > 100
+    assert len(tsinfo.chromsizes) > 2
+    # TODO: Do something with the return value

--- a/test/tiles/chromsizes_test.py
+++ b/test/tiles/chromsizes_test.py
@@ -12,7 +12,6 @@ def test_get_tileset_info():
 
     assert tsinfo.max_width > 100
     assert len(tsinfo.chromsizes) > 2
-    # TODO: Do something with the return value
 
     with open(filename, "rb") as f:
         # Test loading using a file-like object

--- a/test/tiles/chromsizes_test.py
+++ b/test/tiles/chromsizes_test.py
@@ -14,7 +14,7 @@ def test_get_tileset_info():
     assert len(tsinfo.chromsizes) > 2
     # TODO: Do something with the return value
 
-    with open(filename, "r") as f:
+    with open(filename, "rb") as f:
         # Test loading using a file-like object
         tsinfo = TilesetInfo(**ctcs.tileset_info(f))
 


### PR DESCRIPTION
## Description

What was changed in this pull request?

- Adds a tileset_info function for chromsizes objects

Why is it necessary?

- Allows us to phase out loading chromosome sizes from bespoke /chrom-info paths in higlass-server

Fixes #\_\_\_

## Checklist

-   [x] Unit tests added or updated
-   [x] Updated CHANGELOG.md
-   [x] Run `black .`
