### PR TITLE
Fix overflow on combining numpy and python numbers

### DIFF
--- a/clodius/tiles/cooler.py
+++ b/clodius/tiles/cooler.py
@@ -495,7 +495,7 @@ def make_mats(filepath):
 
         # get the genome size
         resolution = list(f["resolutions"].keys())[0]
-        genome_length = int(sum(f["resolutions"][resolution]["chroms"]["length"]))
+        genome_length = int(np.sum(f["resolutions"][resolution]["chroms"]["length"]))
 
         info["max_pos"] = [genome_length, genome_length]
         info["min_pos"] = [1, 1]

--- a/clodius/tiles/format.py
+++ b/clodius/tiles/format.py
@@ -36,8 +36,8 @@ def format_dense_tile(data):
     tile_data["min_value"] = min_dense if not np.isnan(min_dense) else "NaN"
     tile_data["max_value"] = max_dense if not np.isnan(max_dense) else "NaN"
 
-    min_f16 = np.finfo("float16").min
-    max_f16 = np.finfo("float16").max
+    min_f16 = np.finfo("float16").min.item()
+    max_f16 = np.finfo("float16").max.item()
 
     has_nan = np.sum(np.isnan(data)) > 0
     n_dim = len(data.shape)


### PR DESCRIPTION
## Description

Avoid mixing builtin types and small numpy dtypes in situations that may cause overflow.

Why is it necessary?

Fixes #159 

## Checklist

-   [ ] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [ ] Run `black .`
