### PR TITLE
Implemented support for Zarr-based multivec files and an HDF5-Zarr multivec converter

### DIFF
--- a/clodius/cli/convert.py
+++ b/clodius/cli/convert.py
@@ -194,9 +194,9 @@ def _bedgraph_to_multivec(
                 num_rows,
             )
         elif format == "states":
-            assert (
-                row_infos is not None
-            ), "A row_infos file must be provided for --format = 'states' "
+            assert row_infos is not None, (
+                "A row_infos file must be provided for --format = 'states' "
+            )
             states_names = [lne.decode("utf8").split("\t")[0] for lne in row_infos]
             states_dic = {states_names[x]: x for x in range(len(row_infos))}
 
@@ -541,3 +541,34 @@ def bigwigs_to_multivec(
             output_file=output_file,
             row_infos=row_infos,
         )
+
+
+@convert.command()
+@click.argument("input_file", metavar="INPUT_FILE")
+@click.argument("output_file", metavar="OUTPUT_FILE")
+@click.option(
+    "--tile-size",
+    "-t",
+    type=int,
+    help=(
+        "The number of data points in each tile. "
+        "Used to determine the number of zoom levels to create. "
+        "Will try to use the tile size from the input file if it's available, "
+        "otherwise defaults to 65536"
+    ),
+)
+def hdf5_multivec_to_zarr(input_file, output_file, tile_size):
+    """
+    Convert an HDF5 multivec file to Zarr format.
+
+    INPUT_FILE: Path to the input HDF5 multivec file (.mv5)
+    OUTPUT_FILE: Path to the output Zarr multivec file (.zarr)
+    """
+    if not op.exists(input_file):
+        raise click.FileError(input_file, hint="Input file does not exist")
+
+    try:
+        cmv.hdf5_multivec_to_zarr(input_file, output_file, tile_size=tile_size)
+        click.echo(f"Successfully converted {input_file} to {output_file}")
+    except Exception as e:
+        raise click.ClickException(f"Conversion failed: {str(e)}")

--- a/clodius/multivec.py
+++ b/clodius/multivec.py
@@ -9,6 +9,7 @@ import sys
 
 import h5py
 import numpy as np
+import zarr
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,6 @@ def bedfile_to_multivec(
 
     print("base_resolution:", base_resolution)
     for _, lines in enumerate(zip(*files)):
-
         # Identifies bedfile headers and ignore them
         if lines[0].startswith("browser") or lines[0].startswith("track"):
             continue
@@ -75,9 +75,9 @@ def bedfile_to_multivec(
             # the previous values
             # print("len(batch:", len(batch),
             #       "batch_start_index", batch_start_index)
-            f_out[prev_chrom][
-                batch_start_index : batch_start_index + len(batch)
-            ] = np.array(batch)
+            f_out[prev_chrom][batch_start_index : batch_start_index + len(batch)] = (
+                np.array(batch)
+            )
 
             # we're starting a new chromosome so we start from the beginning
             curr_index = 0
@@ -107,9 +107,7 @@ def bedfile_to_multivec(
             message = """
 The expected position location does not match the observed location at entry {}:{}-{}
 This is probably because the bedfile is not sorted. Please sort and try again.
-            """.format(
-                chrom, start, end
-            )
+            """.format(chrom, start, end)
             raise ValueError(message)
         # assert curr_index == data_start_index, message
         # print('vector', vector)
@@ -129,9 +127,9 @@ This is probably because the bedfile is not sorted. Please sort and try again.
         if len(batch) >= batch_length:
             # dump batch
             try:
-                f_out[chrom][
-                    batch_start_index : batch_start_index + len(batch)
-                ] = np.array(batch)
+                f_out[chrom][batch_start_index : batch_start_index + len(batch)] = (
+                    np.array(batch)
+                )
             except TypeError as ex:
                 print("Error:", ex, file=sys.stderr)
                 print("Probably need to set the --num-rows parameter", file=sys.stderr)
@@ -352,3 +350,111 @@ def create_multivec_multires(
 
         prev_resolution = curr_resolution
     return f
+
+
+def _convert_numpy_for_json(attr_value):
+    """
+    Convert numpy types to native Python types for JSON compatibility.
+
+    Parameters
+    ----------
+    attr_value : any
+        The attribute value to convert
+
+    Returns
+    -------
+    any
+        The converted value with native Python types
+    """
+    if isinstance(attr_value, np.integer):
+        return int(attr_value)
+    elif isinstance(attr_value, np.floating):
+        return float(attr_value)
+    elif isinstance(attr_value, np.ndarray):
+        return attr_value.tolist()
+    return attr_value
+
+
+def hdf5_multivec_to_zarr(hdf5_path, zarr_path, *, tile_size=None):
+    """
+    Convert an HDF5 multivec file to Zarr format.
+
+    Parameters
+    ----------
+    hdf5_path : str
+        Path to the input HDF5 multivec file
+    zarr_path : str
+        Path to the output Zarr multivec file
+    """
+    with h5py.File(hdf5_path, "r") as h5f:
+        zarr_store = zarr.open(zarr_path, mode="w")
+
+        if "info" in h5f:
+            if tile_size:
+                # Use specified tile size
+                pass
+            elif "tile-size" in h5f["info"].attrs:
+                tile_size = int(h5f["info"].attrs["tile-size"])
+            else:
+                # Default tile size if not specified nor defined by HDF5
+                tile_size = 2**16
+
+            info_group = zarr_store.create_group("info")
+            for attr_name, attr_value in h5f["info"].attrs.items():
+                info_group.attrs[attr_name] = _convert_numpy_for_json(attr_value)
+
+        if "chroms" in h5f:
+            chroms_group = zarr_store.create_group("chroms")
+            for dataset_name in h5f["chroms"]:
+                dataset = h5f["chroms"][dataset_name]
+                zarr_dataset = chroms_group.create_array(
+                    dataset_name,
+                    data=dataset[:],
+                    chunks=(tile_size,)
+                    if len(dataset.shape) == 1
+                    else (tile_size, dataset.shape[1]),
+                )
+                for attr_name, attr_value in dataset.attrs.items():
+                    zarr_dataset.attrs[attr_name] = _convert_numpy_for_json(attr_value)
+
+        if "resolutions" in h5f:
+            resolutions_group = zarr_store.create_group("resolutions")
+
+            for resolution_name in h5f["resolutions"]:
+                resolution_group = resolutions_group.create_group(resolution_name)
+                h5_resolution = h5f["resolutions"][resolution_name]
+
+                for attr_name, attr_value in h5_resolution.attrs.items():
+                    resolution_group.attrs[attr_name] = _convert_numpy_for_json(
+                        attr_value
+                    )
+
+                if "chroms" in h5_resolution:
+                    res_chroms_group = resolution_group.create_group("chroms")
+                    for dataset_name in h5_resolution["chroms"]:
+                        dataset = h5_resolution["chroms"][dataset_name]
+                        zarr_dataset = res_chroms_group.create_array(
+                            dataset_name,
+                            data=dataset[:],
+                            chunks=(tile_size,)
+                            if len(dataset.shape) == 1
+                            else (tile_size, dataset.shape[1]),
+                        )
+                        for attr_name, attr_value in dataset.attrs.items():
+                            zarr_dataset.attrs[attr_name] = _convert_numpy_for_json(
+                                attr_value
+                            )
+
+                if "values" in h5_resolution:
+                    values_group = resolution_group.create_group("values")
+                    for chrom_name in h5_resolution["values"]:
+                        dataset = h5_resolution["values"][chrom_name]
+                        zarr_dataset = values_group.create_array(
+                            chrom_name,
+                            data=dataset[:],
+                            chunks=(tile_size, dataset.shape[1]),
+                        )
+                        for attr_name, attr_value in dataset.attrs.items():
+                            zarr_dataset.attrs[attr_name] = _convert_numpy_for_json(
+                                attr_value
+                            )

--- a/clodius/tiles/multivec.py
+++ b/clodius/tiles/multivec.py
@@ -1,14 +1,96 @@
 import base64
 import json
 import math
+from contextlib import contextmanager
+from enum import Enum
+from typing import Literal, Union
 
 import h5py
 import numpy as np
 
+try:
+    import zarr
+except ImportError:
+    zarr = None
+
 from .utils import abs2genomic
 
 
-def tiles(filename, tile_ids):
+class StorageBackend(Enum):
+    """Supported storage backends for multivec datasets."""
+
+    HDF5 = "hdf5"
+    if zarr:
+        ZARR = "zarr"
+
+
+def _open_dataset(
+    filename: str, storage: Union[StorageBackend, Literal["hdf5", "zarr"]]
+) -> Union[h5py.File, zarr.Group]:
+    """Internal helper function for opening datasets. Use open_dataset() context manager instead."""
+    if isinstance(storage, str):
+        storage = StorageBackend(storage)
+
+    if storage == StorageBackend.HDF5:
+        return h5py.File(filename, "r")
+    elif storage == StorageBackend.ZARR:
+        if not zarr:
+            raise ImportError("Zarr is not installed")
+        return zarr.open_group(filename, mode="r")
+    else:
+        raise ValueError(f"Unsupported storage backend: {storage}")
+
+
+def _close_dataset(dataset, storage: Union[StorageBackend, Literal["hdf5", "zarr"]]):
+    """Internal helper function for closing datasets. Use open_dataset() context manager instead."""
+    if isinstance(storage, str):
+        storage = StorageBackend(storage)
+
+    if storage == StorageBackend.HDF5:
+        dataset.close()
+    elif storage == StorageBackend.ZARR:
+        if hasattr(dataset, "store") and hasattr(dataset.store, "close"):
+            try:
+                dataset.store.close()
+            except Exception:
+                pass
+
+
+@contextmanager
+def open_dataset(
+    filename: str,
+    storage: Union[StorageBackend, Literal["hdf5", "zarr"]] = StorageBackend.HDF5,
+):
+    """
+    Context manager for opening and closing multivec datasets.
+
+    Parameters
+    ----------
+    filename : str
+        Path to the dataset file
+    storage : StorageBackend or str, optional
+        Storage backend to use: StorageBackend.HDF5 or StorageBackend.ZARR
+
+    Yields
+    ------
+    dataset : h5py.File or zarr.Group
+        The opened dataset object
+    """
+    if isinstance(storage, str):
+        storage = StorageBackend(storage)
+
+    dataset = _open_dataset(filename, storage)
+    try:
+        yield dataset
+    finally:
+        _close_dataset(dataset, storage)
+
+
+def tiles(
+    filename,
+    tile_ids,
+    storage: Union[StorageBackend, Literal["hdf5", "zarr"]] = StorageBackend.HDF5,
+):
     """
     Retrieve multiple multivec tiles from tids.
     ----------
@@ -17,13 +99,15 @@ def tiles(filename, tile_ids):
     tile_ids: [str,...]
         A list of tile_ids (e.g. xyx.0.0) identifying the tiles
         to be retrieved
+    storage: StorageBackend, optional
+        Storage backend to use: HDF5 or Zarr (defaults to HDF5)
     """
     f16 = np.finfo("float16")
     f16_min, f16_max = f16.min, f16.max
     generated_tiles = []
     for tile_id in tile_ids:
         tile_pos = [int(i) for i in tile_id.split(".")[1:3]]
-        ma = get_single_tile(filename, tile_pos)
+        ma = get_single_tile(filename, tile_pos, storage=storage)
         has_nan = np.isnan(ma).any()
         ma_max = ma.max() if ma.size else 0
         ma_min = ma.min() if ma.size else 0
@@ -40,7 +124,11 @@ def tiles(filename, tile_ids):
     return generated_tiles
 
 
-def get_single_tile(filename, tile_pos):
+def get_single_tile(
+    filename,
+    tile_pos,
+    storage: Union[StorageBackend, Literal["hdf5", "zarr"]] = StorageBackend.HDF5,
+):
     """
     Retrieve a single multivec tile from a multires file
     Parameters
@@ -49,34 +137,57 @@ def get_single_tile(filename, tile_pos):
         The multires file containing the multivec data
     tile_pos: (z, x)
         The zoom level and position of this tile
+    storage: StorageBackend, optional
+        Storage backend to use: HDF5 or Zarr (defaults to HDF5)
     """
+    # Handle backward compatibility with string inputs
+    if isinstance(storage, str):
+        storage = StorageBackend(storage)
+
     # t1 = time.time()
-    tsinfo = tileset_info(filename)
-    f = h5py.File(filename, "r")
+    tsinfo = tileset_info(filename, storage=storage)
 
-    # print('tileset_info', tileset_info)
-    # t2 = time.time()
-    # which resolution does this zoom level correspond to?
-    resolution = tsinfo["resolutions"][tile_pos[0]]
-    tile_size = tsinfo["tile_size"]
+    with open_dataset(filename, storage) as f:
+        # print('tileset_info', tileset_info)
+        # t2 = time.time()
+        # which resolution does this zoom level correspond to?
+        resolution = tsinfo["resolutions"][tile_pos[0]]
+        tile_size = tsinfo["tile_size"]
 
-    # where in the data does the tile start and end
-    tile_start = tile_pos[1] * tile_size * resolution
-    tile_end = tile_start + tile_size * resolution
+        # where in the data does the tile start and end
+        tile_start = tile_pos[1] * tile_size * resolution
+        tile_end = tile_start + tile_size * resolution
 
-    chromsizes = list(zip(f["chroms"]["name"], f["chroms"]["length"]))
+        if storage == StorageBackend.HDF5:
+            chromsizes = list(zip(f["chroms"]["name"], f["chroms"]["length"]))
+        else:  # zarr
+            chrom_names = f["chroms"]["name"][:]
+            chrom_lengths = f["chroms"]["length"][:]
+            # Handle byte string decoding for zarr
+            decoded_names = []
+            for name in chrom_names:
+                if hasattr(name, "item"):
+                    name = name.item()
+                if isinstance(name, bytes):
+                    decoded_names.append(name.decode("utf-8"))
+                else:
+                    decoded_names.append(str(name))
+            chromsizes = list(zip(decoded_names, chrom_lengths))
 
-    # dense = f['resolutions'][str(resolution)][tile_start:tile_end]
-    dense = get_tile(f, chromsizes, resolution, tile_start, tile_end, tsinfo["shape"])
-    # print("dense.shape", dense.shape)
-
-    if len(dense) < tsinfo["tile_size"]:
-        # if there aren't enough rows to fill this tile, add some zeros
-        dense = np.vstack(
-            [dense, np.zeros((tsinfo["tile_size"] - len(dense), tsinfo["shape"][1]))]
+        # dense = f['resolutions'][str(resolution)][tile_start:tile_end]
+        dense = get_tile(
+            f, chromsizes, resolution, tile_start, tile_end, tsinfo["shape"], storage
         )
+        # print("dense.shape", dense.shape)
 
-    f.close()
+        if len(dense) < tsinfo["tile_size"]:
+            # if there aren't enough rows to fill this tile, add some zeros
+            dense = np.vstack(
+                [
+                    dense,
+                    np.zeros((tsinfo["tile_size"] - len(dense), tsinfo["shape"][1])),
+                ]
+            )
 
     # t3 = time.time()
     # print("single time time: {:.2f} (tileset info: {:.2f}, open time: {:.2f})".format(t3 - t1, t15 - t1, t2 - t15))
@@ -84,7 +195,15 @@ def get_single_tile(filename, tile_pos):
     return dense.T
 
 
-def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
+def get_tile(
+    f,
+    chromsizes,
+    resolution,
+    start_pos,
+    end_pos,
+    shape,
+    storage: Union[StorageBackend, Literal["hdf5", "zarr"]] = StorageBackend.HDF5,
+):
     """
     Get the tile value given the start and end positions and
     chromosome positions.
@@ -94,8 +213,8 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
 
     Parameters:
     -----------
-    f: h5py.File
-        An hdf5 file containing the data
+    f: h5py.File or zarr.Group
+        A file/group containing the data
     chromsizes: [('chr1', 1000), ....]
         An array listing the chromosome sizes
     resolution: int
@@ -105,6 +224,8 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
         The start_position of the interval to return
     end_pos: int
         The end position of the interval to return
+    storage: StorageBackend
+        Storage backend to use: HDF5 or Zarr (defaults to HDF5)
 
     Returns
     -------
@@ -112,6 +233,10 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
         A subset of the original genome-wide values containing
         the values for the portion of the genome that is visible.
     """
+    # Handle backward compatibility with string inputs
+    if isinstance(storage, str):
+        storage = StorageBackend(storage)
+
     binsize = resolution
     # print('binsize:', binsize)
     # print('start_pos:', start_pos, 'end_pos:', end_pos)
@@ -168,7 +293,14 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
             """
 
             # print("offset:", offset, "start_pos", start_pos, end_pos)
-            x = f["resolutions"][str(resolution)]["values"][chrom][start_pos:end_pos]
+            if storage == StorageBackend.HDF5:
+                x = f["resolutions"][str(resolution)]["values"][chrom][
+                    start_pos:end_pos
+                ]
+            else:  # zarr
+                x = f["resolutions"][str(resolution)]["values"][chrom][
+                    start_pos:end_pos
+                ]
             current_binned_data_position += binsize * (end_pos - start_pos)
 
             # print("x:", x.shape)
@@ -208,7 +340,10 @@ def get_tile(f, chromsizes, resolution, start_pos, end_pos, shape):
     return np.concatenate(arrays)[: shape[0]]
 
 
-def tileset_info(filename):
+def tileset_info(
+    filename,
+    storage: Union[StorageBackend, Literal["hdf5", "zarr"]] = StorageBackend.HDF5,
+):
     """
     Return some information about this tileset that will
     help render it in on the client.
@@ -216,68 +351,92 @@ def tileset_info(filename):
     Parameters
     ----------
     filename: str
-      The filename of the h5py file containing the tileset info.
+        The filename of the file containing the tileset info.
+    storage: StorageBackend, optional
+        Storage backend to use: StorageBackend.HDF5 or StorageBackend.ZARR
 
     Returns
     -------
     tileset_info: {}
-      A dictionary containing the information describing
-      this dataset
+        A dictionary containing the information describing
+        this dataset
     """
+    # Handle backward compatibility with string inputs
+    if isinstance(storage, str):
+        storage = StorageBackend(storage)
+
     # t1 = time.time()
-    f = h5py.File(filename, "r")
-    # t2 = time.time()
-    # a sorted list of resolutions, lowest to highest
-    # awkward to write because a the numbers representing resolution
-    # are datapoints / pixel so lower resolution is actually a higher
-    # number
-    resolutions = sorted([int(r) for r in f["resolutions"].keys()])[::-1]
+    with open_dataset(filename, storage) as f:
+        # t2 = time.time()
+        # a sorted list of resolutions, lowest to highest
+        # awkward to write because a the numbers representing resolution
+        # are datapoints / pixel so lower resolution is actually a higher
+        # number
+        resolutions = sorted([int(r) for r in f["resolutions"].keys()])[::-1]
 
-    # the "leftmost" datapoint position
-    # an array because higlass can display multi-dimensional
-    # data
-    min_pos = [0]
-    max_pos = [int(sum(f["chroms"]["length"][:]))]
+        # the "leftmost" datapoint position
+        # an array because higlass can display multi-dimensional
+        # data
+        min_pos = [0]
+        if storage == StorageBackend.HDF5:
+            max_pos = [int(sum(f["chroms"]["length"][:]))]
+        else:  # zarr
+            max_pos = [int(sum(f["chroms"]["length"][:]))]
 
-    # the "rightmost" datapoint position
-    # max_pos = [len(f['resolutions']['values'][str(resolutions[-1])])]
-    tile_size = int(f["info"].attrs["tile-size"])
-    first_chrom = f["chroms"]["name"][0]
+        # the "rightmost" datapoint position
+        # max_pos = [len(f['resolutions']['values'][str(resolutions[-1])])]
+        if storage == StorageBackend.HDF5:
+            tile_size = int(f["info"].attrs["tile-size"])
+            first_chrom = f["chroms"]["name"][0]
+        else:  # zarr
+            tile_size = int(f["info"].attrs["tile-size"])
+            first_chrom_raw = f["chroms"]["name"][0]
+            # Handle byte string decoding for zarr
+            if hasattr(first_chrom_raw, "item"):
+                first_chrom_raw = first_chrom_raw.item()
+            if isinstance(first_chrom_raw, bytes):
+                first_chrom = first_chrom_raw.decode("utf-8")
+            else:
+                first_chrom = str(first_chrom_raw)
 
-    shape = list(f["resolutions"][str(resolutions[0])]["values"][first_chrom].shape)
-    shape[0] = tile_size
+        shape = list(f["resolutions"][str(resolutions[0])]["values"][first_chrom].shape)
+        shape[0] = tile_size
 
-    # t3 = time.time()
-    # print("tileset info time:", t3 - t2)
+        # t3 = time.time()
+        # print("tileset info time:", t3 - t2)
 
-    tileset_info = {
-        "resolutions": resolutions,
-        "min_pos": min_pos,
-        "max_pos": max_pos,
-        "tile_size": tile_size,
-        "shape": shape,
-    }
+        tileset_info = {
+            "resolutions": resolutions,
+            "min_pos": min_pos,
+            "max_pos": max_pos,
+            "tile_size": tile_size,
+            "shape": shape,
+        }
 
-    if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
-        row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
+        if storage == StorageBackend.HDF5:
+            if "row_infos" in f["resolutions"][str(resolutions[0])].attrs:
+                row_infos = f["resolutions"][str(resolutions[0])].attrs["row_infos"]
 
-        if isinstance(row_infos[0], str):
-            try:
-                tileset_info["row_infos"] = [json.loads(r) for r in row_infos]
-            except json.JSONDecodeError:
-                tileset_info["row_infos"] = [r for r in row_infos]
+                if isinstance(row_infos[0], str):
+                    try:
+                        tileset_info["row_infos"] = [json.loads(r) for r in row_infos]
+                    except json.JSONDecodeError:
+                        tileset_info["row_infos"] = [r for r in row_infos]
+                else:
+                    try:
+                        tileset_info["row_infos"] = [
+                            json.loads(r.decode("utf8")) for r in row_infos
+                        ]
+                    except json.JSONDecodeError:
+                        tileset_info["row_infos"] = [
+                            r.decode("utf8") for r in row_infos
+                        ]
+
+            elif "row_infos" in f["info"]:
+                row_infos_encoded = f["info"]["row_infos"][()]
+                tileset_info["row_infos"] = json.loads(row_infos_encoded)
         else:
-            try:
-                tileset_info["row_infos"] = [
-                    json.loads(r.decode("utf8")) for r in row_infos
-                ]
-            except json.JSONDecodeError:
-                tileset_info["row_infos"] = [r.decode("utf8") for r in row_infos]
-
-    elif "row_infos" in f["info"]:
-        row_infos_encoded = f["info"]["row_infos"][()]
-        tileset_info["row_infos"] = json.loads(row_infos_encoded)
-
-    f.close()
+            if "row_infos" in f["info"].attrs:
+                tileset_info["row_infos"] = f["info"].attrs["row_infos"]
 
     return tileset_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "slugid",
     "sortedcontainers",
     "tqdm",
-    "smart_open"
+    "smart_open",
 ]
 license = { text = "MIT" }
 readme = "README.md"
@@ -42,6 +42,9 @@ dev = [
     "flake8",
     "pytest",
     "pytest-cov",
+]
+zarr = [
+    "zarr>=3.1.0",
 ]
 
 [tool.pytest.ini_options]

--- a/test/multivec_test.py
+++ b/test/multivec_test.py
@@ -3,9 +3,12 @@ from __future__ import print_function
 import click.testing as clt
 import clodius.cli.convert as ccc
 import clodius.tiles.multivec as ctv
+import clodius.multivec as cm
 import os.path as op
 import tempfile
 import h5py
+import zarr
+import numpy as np
 
 testdir = op.realpath(op.dirname(__file__))
 
@@ -195,7 +198,6 @@ def test_retain_lines():
 
 
 def test_chr_boundaries_states():
-
     data_file = op.join(testdir, "sample_data", "chrm_boundaries_test.multires.mv5")
     f = h5py.File(data_file, "r")
 
@@ -218,3 +220,42 @@ def test_chr_boundaries_states():
 
     assert tile3[135][0] == 1.0 and tile3[135][1] == 0.0
     assert tile3[136][0] == 0.0 and tile3[136][1] == 1.0
+
+
+def test_hdf5_multivec_to_zarr():
+    hdf5_file = op.join(
+        testdir, "sample_data", "3_header_100_testfile.bed.multires.mv5"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        zarr_file = op.join(tmp_dir, "converted.zarr")
+
+        cm.hdf5_multivec_to_zarr(hdf5_file, zarr_file)
+
+        with h5py.File(hdf5_file, "r") as h5f:
+            zarr_store = zarr.open(zarr_file, mode="r")
+
+            assert "resolutions" in zarr_store
+            assert "chroms" in zarr_store
+
+            # Check that we have the same resolutions
+            h5_resolutions = set(h5f["resolutions"].keys())
+            zarr_resolutions = set(zarr_store["resolutions"].keys())
+            assert h5_resolutions == zarr_resolutions
+
+            # Check data integrity for one resolution
+            if "200" in h5f["resolutions"]:
+                resolution = "200"
+                h5_values = h5f["resolutions"][resolution]["values"]
+                zarr_values = zarr_store["resolutions"][resolution]["values"]
+
+                # Check that all chromosomes are present
+                h5_chroms = set(h5_values.keys())
+                zarr_chroms = set(zarr_values.keys())
+                assert h5_chroms == zarr_chroms
+
+                # Check data for each chromosome
+                for chrom in h5_chroms:
+                    np.testing.assert_array_equal(
+                        h5_values[chrom][:], zarr_values[chrom][:]
+                    )

--- a/test/tiles/multivec_test.py
+++ b/test/tiles/multivec_test.py
@@ -2,8 +2,10 @@ import os.path as op
 import base64
 
 import h5py
+import numpy as np
 import pytest
 import clodius.tiles.multivec as hgmu
+import clodius.multivec as mv
 
 
 def test_multivec():
@@ -42,9 +44,7 @@ def test_multivec():
 
 
 def test_states():
-    filename = op.join(
-        "data", "states_format_input_testfile.100.bed.multires.mv5"
-    )
+    filename = op.join("data", "states_format_input_testfile.100.bed.multires.mv5")
 
     # make sure we can retrieve the tileset info
     tsinfo = hgmu.tileset_info(filename)
@@ -52,3 +52,84 @@ def test_states():
 
     tiles = hgmu.tiles(filename, ["x.0.0"])
     assert "shape" in tiles[0][1]
+
+
+@pytest.fixture
+def zarr_sample_multivec(tmp_path):
+    """Convert sample_gwas.multires.mv5 to zarr format in a temporary directory."""
+    hdf5_path = op.join("test/sample_data", "sample_gwas.multires.mv5")
+    zarr_path = tmp_path / "sample_gwas.multires.zarr"
+
+    mv.hdf5_multivec_to_zarr(hdf5_path, str(zarr_path))
+    return str(zarr_path)
+
+
+def test_zarr_multivec_tileset_info(zarr_sample_multivec):
+    """Test tileset_info works with zarr storage backend."""
+    info = hgmu.tileset_info(zarr_sample_multivec, storage="zarr")
+
+    # Compare with HDF5 version
+    hdf5_path = op.join("test/sample_data", "sample_gwas.multires.mv5")
+    hdf5_info = hgmu.tileset_info(hdf5_path, storage="hdf5")
+    assert info["shape"] == hdf5_info["shape"]
+    assert info["tile_size"] == hdf5_info["tile_size"]
+    assert info["max_pos"] == hdf5_info["max_pos"]
+    assert set(info["resolutions"]) == set(hdf5_info["resolutions"])
+
+
+def test_zarr_multivec_get_single_tile(zarr_sample_multivec):
+    """Test get_single_tile works with zarr storage backend."""
+    zarr_tile = hgmu.get_single_tile(zarr_sample_multivec, [0, 0], storage="zarr")
+
+    # Compare with HDF5 version
+    hdf5_path = op.join("test/sample_data", "sample_gwas.multires.mv5")
+    hdf5_tile = hgmu.get_single_tile(hdf5_path, [0, 0], storage="hdf5")
+    assert zarr_tile.shape == hdf5_tile.shape
+    assert np.allclose(zarr_tile, hdf5_tile, equal_nan=True)
+
+    # Test error handling
+    info = hgmu.tileset_info(zarr_sample_multivec, storage="zarr")
+    with pytest.raises(IndexError):
+        hgmu.get_single_tile(
+            zarr_sample_multivec, [len(info["resolutions"]), 0], storage="zarr"
+        )
+
+
+def test_zarr_multivec_tiles(zarr_sample_multivec):
+    """Test tiles function works with zarr storage backend."""
+    # Get available resolutions
+    info = hgmu.tileset_info(zarr_sample_multivec, storage="zarr")
+    resolutions = info["resolutions"]
+
+    # Create tile IDs for testing
+    tids = [f"test_uuid.{level}.0.1231.123" for level in range(len(resolutions))]
+    zarr_tiles = hgmu.tiles(zarr_sample_multivec, tids, storage="zarr")
+    zarr_tiles_list = list(zarr_tiles)
+
+    # Compare with HDF5 version
+    hdf5_path = op.join("test/sample_data", "sample_gwas.multires.mv5")
+    hdf5_tiles = hgmu.tiles(hdf5_path, tids, storage="hdf5")
+    hdf5_tiles_list = list(hdf5_tiles)
+    assert len(zarr_tiles_list) == len(hdf5_tiles_list)
+    for (zarr_tile_id, zarr_tile_value), (hdf5_tile_id, hdf5_tile_value) in zip(
+        zarr_tiles_list, hdf5_tiles_list
+    ):
+        assert zarr_tile_id == hdf5_tile_id
+        assert zarr_tile_value["dense"] == hdf5_tile_value["dense"]
+        assert zarr_tile_value["dtype"] == hdf5_tile_value["dtype"]
+
+
+def test_zarr_multivec_consistency(zarr_sample_multivec):
+    """Test that zarr tiles match single tile retrieval."""
+    info = hgmu.tileset_info(zarr_sample_multivec, storage="zarr")
+    resolutions = info["resolutions"]
+    tids = [f"test_uuid.{level}.0.1231.123" for level in range(len(resolutions))]
+    tiles = hgmu.tiles(zarr_sample_multivec, tids, storage="zarr")
+    for tile_id, tile_value in tiles:
+        tile_pos = [int(i) for i in tile_id.split(".")[1:3]]
+        single_tile = hgmu.get_single_tile(
+            zarr_sample_multivec, tile_pos, storage="zarr"
+        ).astype(tile_value["dtype"])
+        assert (
+            base64.b64encode(single_tile.ravel()).decode("utf-8") == tile_value["dense"]
+        )


### PR DESCRIPTION
## Description

What was changed in this pull request?

I've added Zarr support to the mutlivec tileset logic. It'll default to HDF5, but the option to read from Zarr is there.

Why is it necessary?

Zarr is a scalable array storage format that aligns nicely with the concept of a tileset. It should be more efficient to read Zarr than HDF5, particularly for large mutlivecs living on cloud-based object storage.

Fixes #162 

## Checklist

-   [x] Unit tests added or updated
-   [ ] Updated CHANGELOG.md
-   [x] Run `black .`
