### PR TITLE
Add configurable feature_type to gff single_tile

### DIFF
--- a/clodius/tiles/gff.py
+++ b/clodius/tiles/gff.py
@@ -43,7 +43,7 @@ def row_to_bedlike(row, css, orig_columns):
         "xEnd": row["xEnd"],
         "chrOffset": css[row[0]],
         "importance": random.random(),
-        "fields": [row[0], row[3], row[4], attrs["Name"], "-", row[6]],
+        "fields": [row[0], row[3], row[4], attrs.get("Name", attrs.get("ID", "")), "-", row[6]],
     }
 
     return ret
@@ -97,10 +97,12 @@ def single_tile(filename, chromsizes, tsinfo, z, x, settings=None):
     if isinstance(filename, str):
         filename = open(filename, "rb")
 
-    hash_ = ctb.ts_hash(filename, chromsizes)
-
     if settings is None:
         settings = {}
+
+    target_feature = settings.get("feature_type", "gene")
+    hash_ = f"{ctb.ts_hash(filename, chromsizes)}:{target_feature}"
+
     # hash the loaded data table so that we don't have to read the entire thing
     # and calculate cumulative start and end positions
     val = ctb.cache.get(hash_)
@@ -113,14 +115,14 @@ def single_tile(filename, chromsizes, tsinfo, z, x, settings=None):
             delimiter="\t",
             compression=get_file_compression(filename),
         )
-        t = t[t[2] == "gene"]
+        t = t[t[2] == target_feature]
 
         orig_columns = t.columns
         css = chromsizes.cumsum().shift().fillna(0).to_dict()
 
         # xStart and xEnd are cumulative start and end positions calculated
         # as if the chromosomes are concatenated from end to end
-        t["chromStart"] = t[0].map(lambda x: css[x])
+        t["chromStart"] = t[0].map(lambda x: css[x]).astype(float)
         t["xStart"] = t["chromStart"] + t[3]
         t["xEnd"] = t["chromStart"] + t[4]
         t["ix"] = t.index

--- a/test/gff_test.py
+++ b/test/gff_test.py
@@ -29,6 +29,54 @@ def test_tiles():
     assert len(tiles1[0][1]["genes"].keys()) < len(tiles[0][1]["genes"].keys())
 
 
+def test_single_tile_default_feature_type():
+    """single_tile defaults to filtering on 'gene' features."""
+    filename = op.join("data", "GCA_002918705.1_ASM291870v1_genomic.gff.gz")
+    chromsizes = ctg.gff_chromsizes(filename)
+    tsinfo = ctg.tileset_info(filename, chromsizes)
+
+    result = ctg.single_tile(filename, chromsizes, tsinfo, z=0, x=0)
+
+    assert len(result) > 0
+    # Sanity-check: explicit feature_type="gene" produces the same count.
+    result_explicit = ctg.single_tile(
+        filename, chromsizes, tsinfo, z=0, x=0, settings={"feature_type": "gene"}
+    )
+    assert len(result) == len(result_explicit)
+
+
+def test_single_tile_custom_feature_type():
+    """single_tile respects a custom feature_type passed via settings."""
+    filename = op.join("data", "GCA_002918705.1_ASM291870v1_genomic.gff.gz")
+    chromsizes = ctg.gff_chromsizes(filename)
+    tsinfo = ctg.tileset_info(filename, chromsizes)
+
+    gene_result = ctg.single_tile(filename, chromsizes, tsinfo, z=0, x=0)
+    cds_result = ctg.single_tile(
+        filename, chromsizes, tsinfo, z=0, x=0, settings={"feature_type": "CDS"}
+    )
+
+    # CDS features should be present; their row UIDs must differ from gene UIDs
+    # (both may hit the MAX_PER_TILE cap, so count comparison is not meaningful)
+    assert len(cds_result) > 0
+    gene_uids = {r["uid"] for r in gene_result}
+    cds_uids = {r["uid"] for r in cds_result}
+    assert gene_uids != cds_uids
+
+
+def test_single_tile_unknown_feature_type():
+    """single_tile returns an empty list when feature_type has no matches."""
+    filename = op.join("data", "GCA_002918705.1_ASM291870v1_genomic.gff.gz")
+    chromsizes = ctg.gff_chromsizes(filename)
+    tsinfo = ctg.tileset_info(filename, chromsizes)
+
+    result = ctg.single_tile(
+        filename, chromsizes, tsinfo, z=0, x=0, settings={"feature_type": "nonexistent_feature"}
+    )
+
+    assert len(result) == 0
+
+
 def test_indexed_tiles():
     filename = op.join("data", "genomic.10k.gff.gz")
     index = op.join("data", "genomic.10k.gff.gz.tbi")


### PR DESCRIPTION
## Summary

- `single_tile` now accepts `settings={"feature_type": "..."}` to filter on any GFF feature type (e.g. `"CDS"`, `"exon"`, `"tRNA"`). Defaults to `"gene"` for full backwards compatibility.
- The cache key is scoped per `feature_type` so different feature types never share a cached DataFrame.
- Fixed a crash when the filtered DataFrame is empty: pandas/Arrow infers `large_string` dtype from `.map()` on an empty column, causing `str + int64` to fail. Fixed by adding `.astype(float)` on the `chromStart` column.
- Fixed a `KeyError` in `row_to_bedlike` when a feature row lacks a `Name` attribute (e.g. CDS rows); falls back to `ID` then empty string.

## Test plan

- [ ] `test_single_tile_default_feature_type` — default behaviour unchanged, explicit `feature_type="gene"` produces same count
- [ ] `test_single_tile_custom_feature_type` — `feature_type="CDS"` returns results with different row UIDs than gene results
- [ ] `test_single_tile_unknown_feature_type` — unknown feature type returns empty list without error
- [ ] All 6 existing GFF tests pass (`pytest test/gff_test.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)